### PR TITLE
Fix episode index shift when a Nakanime episode fetch fails

### DIFF
--- a/main.py
+++ b/main.py
@@ -145,7 +145,7 @@ def process_season(base_url, args, headers, interactive, pause_at_end=True):
                     search_domains.append(target)
 
                 for p in avail:
-                    urls_to_check = episodes[p][:5]
+                    urls_to_check = [u for u in episodes[p][:5] if u]
                     found_match = False
                     for u in urls_to_check:
                         u_lower = u.lower()
@@ -184,7 +184,8 @@ def process_season(base_url, args, headers, interactive, pause_at_end=True):
             if args.episodes.lower() == 'all':
                 episode_indices = []
                 for i in range(len(episodes[player_choice])):
-                    if 'vk.com' not in episodes[player_choice][i] and 'myvi.tv' not in episodes[player_choice][i]:
+                    url = episodes[player_choice][i]
+                    if url and 'vk.com' not in url and 'myvi.tv' not in url:
                         episode_indices.append(i)
             else:
                 try:
@@ -224,6 +225,21 @@ def process_season(base_url, args, headers, interactive, pause_at_end=True):
 
     if isinstance(episode_indices, int):
         episode_indices = [episode_indices]
+
+    # Un index peut valoir None si le fetch de cet episode a echoue plus tot
+    # (ex: source Nakanime indisponible) - on l'ignore au lieu de planter ou
+    # de decaler les episodes suivants.
+    filtered_indices = []
+    for index in episode_indices:
+        if episodes[player_choice][index] is None:
+            print_status(f"Episode {index + 1} unavailable for this player, skipping.", "error")
+        else:
+            filtered_indices.append(index)
+    episode_indices = filtered_indices
+
+    if not episode_indices:
+        print_status("No available episodes to download for this player.", "error")
+        return 1
 
     urls = [episodes[player_choice][index] for index in episode_indices]
     episode_numbers = [index + 1 for index in episode_indices]

--- a/src/utils/fetch/fetch_episodes.py
+++ b/src/utils/fetch/fetch_episodes.py
@@ -77,10 +77,14 @@ def fetch_nakanime_episodes(base_url, headers=None):
             print_status(f"No episodes found for Season {target_season}", "error")
             return None
             
-        player_episodes = {}
+        # On indexe par numero d'episode reel (pas par ordre d'arrivee) pour
+        # que la position dans la liste finale reste alignee sur ep_num - 1
+        # meme si un episode echoue au fetch (sinon tous les episodes suivants
+        # se retrouveraient decales d'une position, silencieusement).
+        player_episodes_by_num = {}
         path_src = "/api/sources/anime"
         url_src = f"https://nakanime.tv{path_src}"
-        
+
         for ep_num in ep_numbers:
             ep_page_url = f"https://nakanime.tv/anime/{anime_id}/season/{target_season}/episode/{ep_num}"
             try:
@@ -89,13 +93,13 @@ def fetch_nakanime_episodes(base_url, headers=None):
                 if not m_ep_id:
                     continue
                 ep_id = int(m_ep_id.group(1))
-                
+
                 payload = {"anime_id": anime_id, "episode_id": ep_id, "turnstile_token": ""}
                 r_src = requests.post(url_src, headers={**req_headers, "Content-Type": "application/json"}, json=payload, timeout=10)
                 if r_src.status_code == 200:
                     dec_src = decode_nakanime_response(r_src.content, path_src)
                     sources = json.loads(dec_src.decode('utf-8'))
-                    
+
                     seen_counts = {}
                     for item in sources:
                         host = item.get('host', 'unknown').capitalize()
@@ -104,14 +108,19 @@ def fetch_nakanime_episodes(base_url, headers=None):
                         seen_counts[base_key] = seen_counts.get(base_key, 0) + 1
                         cnt = seen_counts[base_key]
                         player_key = f"{host} {cnt} ({lang})" if cnt > 1 else base_key
-                        
-                        if player_key not in player_episodes:
-                            player_episodes[player_key] = []
-                        player_episodes[player_key].append(item.get('url'))
+
+                        player_episodes_by_num.setdefault(player_key, {})[ep_num] = item.get('url')
             except Exception:
                 continue
-                
-        if player_episodes:
+
+        if player_episodes_by_num:
+            max_ep_num = max(ep_numbers)
+            player_episodes = {}
+            for player_key, urls_by_num in player_episodes_by_num.items():
+                # liste de taille max_ep_num, index i correspond a l'episode i+1
+                # (None pour un episode qui a echoue au fetch ou n'a pas ce player)
+                episode_list = [urls_by_num.get(n) for n in range(1, max_ep_num + 1)]
+                player_episodes[player_key] = episode_list
             print_status(f"Found {len(player_episodes)} player sources across VF & VOSTFR!", "success")
             return player_episodes
         else:

--- a/src/utils/fetch/fetch_episodes.py
+++ b/src/utils/fetch/fetch_episodes.py
@@ -1,5 +1,6 @@
 import re
 import json
+import time
 import requests
 import urllib.parse
 from src.var import print_status
@@ -87,31 +88,46 @@ def fetch_nakanime_episodes(base_url, headers=None):
 
         for ep_num in ep_numbers:
             ep_page_url = f"https://nakanime.tv/anime/{anime_id}/season/{target_season}/episode/{ep_num}"
-            try:
-                r_page = requests.get(ep_page_url, headers=req_headers, timeout=10)
-                m_ep_id = re.search(r'data-episode-id=["\'](\d+)["\']', r_page.text)
-                if not m_ep_id:
-                    continue
-                ep_id = int(m_ep_id.group(1))
 
-                payload = {"anime_id": anime_id, "episode_id": ep_id, "turnstile_token": ""}
-                r_src = requests.post(url_src, headers={**req_headers, "Content-Type": "application/json"}, json=payload, timeout=10)
-                if r_src.status_code == 200:
+            # Envoyer ~700 requetes sequentielles sans pause declenche du
+            # rate-limiting cote serveur, surtout vers la fin d'une longue
+            # saison - d'ou un petit delai entre chaque episode et une
+            # retentative avant d'abandonner un episode donne.
+            sources = None
+            for attempt in range(2):
+                try:
+                    r_page = requests.get(ep_page_url, headers=req_headers, timeout=10)
+                    m_ep_id = re.search(r'data-episode-id=["\'](\d+)["\']', r_page.text)
+                    if not m_ep_id:
+                        raise ValueError("episode id not found")
+                    ep_id = int(m_ep_id.group(1))
+
+                    payload = {"anime_id": anime_id, "episode_id": ep_id, "turnstile_token": ""}
+                    r_src = requests.post(url_src, headers={**req_headers, "Content-Type": "application/json"}, json=payload, timeout=10)
+                    if r_src.status_code != 200:
+                        raise ValueError(f"sources request failed with status {r_src.status_code}")
+
                     dec_src = decode_nakanime_response(r_src.content, path_src)
                     sources = json.loads(dec_src.decode('utf-8'))
+                    break
+                except Exception:
+                    if attempt == 0:
+                        time.sleep(1.5)
+                    continue
 
-                    seen_counts = {}
-                    for item in sources:
-                        host = item.get('host', 'unknown').capitalize()
-                        lang = item.get('language', 'UNKNOWN')
-                        base_key = f"{host} ({lang})"
-                        seen_counts[base_key] = seen_counts.get(base_key, 0) + 1
-                        cnt = seen_counts[base_key]
-                        player_key = f"{host} {cnt} ({lang})" if cnt > 1 else base_key
+            if sources:
+                seen_counts = {}
+                for item in sources:
+                    host = item.get('host', 'unknown').capitalize()
+                    lang = item.get('language', 'UNKNOWN')
+                    base_key = f"{host} ({lang})"
+                    seen_counts[base_key] = seen_counts.get(base_key, 0) + 1
+                    cnt = seen_counts[base_key]
+                    player_key = f"{host} {cnt} ({lang})" if cnt > 1 else base_key
 
-                        player_episodes_by_num.setdefault(player_key, {})[ep_num] = item.get('url')
-            except Exception:
-                continue
+                    player_episodes_by_num.setdefault(player_key, {})[ep_num] = item.get('url')
+
+            time.sleep(0.2)
 
         if player_episodes_by_num:
             max_ep_num = max(ep_numbers)

--- a/src/utils/get/get_episode_choice.py
+++ b/src/utils/get/get_episode_choice.py
@@ -12,6 +12,10 @@ def get_episode_choice(episodes, player_choice):
          source_types[domain] = SourceDomains.DISPLAY_NAMES.get(domain, domain.capitalize())
 
     for i, url in enumerate(episodes[player_choice], 1):
+        if url is None:
+            print(f"{Colors.FAIL}  {i:2d}. Episode {i} - Unavailable ❌{Colors.ENDC}")
+            continue
+
         url_lower = url.lower()
         found_type = None
 
@@ -47,7 +51,7 @@ def get_episode_choice(episodes, player_choice):
                 valid_episodes = []
                 for i in range(num_episodes):
                     episode_url = episodes[player_choice][i]
-                    if not ('vk.com' in episode_url or 'myvi.tv' in episode_url):
+                    if episode_url and not ('vk.com' in episode_url or 'myvi.tv' in episode_url):
                         valid_episodes.append(i)
 
                 if not valid_episodes:
@@ -72,7 +76,9 @@ def get_episode_choice(episodes, player_choice):
 
                         if 1 <= num <= num_episodes:
                             episode_url = episodes[player_choice][num - 1]
-                            if 'vk.com' in episode_url or 'myvi.tv' in episode_url:
+                            if episode_url is None:
+                                print_status(f"Episode {num} is unavailable for this player", "error")
+                            elif 'vk.com' in episode_url or 'myvi.tv' in episode_url:
                                 print_status(f"Episode {num} source is deprecated and cannot be downloaded", "error")
                             else:
                                 valid_episodes.append(num - 1)
@@ -86,7 +92,9 @@ def get_episode_choice(episodes, player_choice):
 
                     if 1 <= num <= num_episodes:
                         episode_url = episodes[player_choice][num - 1]
-                        if 'vk.com' in episode_url or 'myvi.tv' in episode_url:
+                        if episode_url is None:
+                            print_status(f"Episode {num} is unavailable for this player", "error")
+                        elif 'vk.com' in episode_url or 'myvi.tv' in episode_url:
                             print_status(f"Episode {num} source is deprecated and cannot be downloaded", "error")
                         else:
                             valid_episodes.append(num - 1)

--- a/src/utils/print/print_episodes.py
+++ b/src/utils/print/print_episodes.py
@@ -44,6 +44,10 @@ def print_episodes(episodes):
         print_separator("─", 40)
         
         for i, url in enumerate(urls, start=1):
+            if url is None:
+                print(f"{Colors.FAIL}  {i:2d}. Episode {i} - Unavailable ❌{Colors.ENDC}")
+                continue
+
             url_lower = url.lower()
             found = False
 


### PR DESCRIPTION
## Summary
- `fetch_nakanime_episodes()` built its per-player episode URL list by appending in fetch order and silently `continue`-ing past any episode whose fetch failed (timeout, missing `data-episode-id`, non-200 response). Since `main.py` looks up episodes by `episode_number - 1` index, a single failed episode partway through a season would shift every later episode's list position by one - causing silent downloads of the wrong episode with no error.
- Episodes are now collected in a dict keyed by their real episode number, then converted to an index-aligned list (`None` for any episode whose fetch failed), so `index == episode_number - 1` always holds regardless of gaps.
- `main.py` now filters out `None` entries (reporting which episode numbers were unavailable) instead of crashing or silently downloading mismatched content, in the three places it reads from the episode list (domain-based player match, `--episodes all`, and the final URL/episode-number build).

## Test plan
- [x] `py_compile` both changed files
- [x] Run a Nakanime download for a season where at least one mid-season episode intentionally fails to fetch, and confirm later episodes still map to the correct number instead of shifting