### PR TITLE
Season-aware MAL matching, verified downloads, stable batch progress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,7 @@ env/
 
 # videos file
 videos/
+
+# Local runtime config (Cloudflare cookie, TVDB API key, save-path/
+# identification settings) - personal, contains secrets, never commit.
+src/utils/config/config.json

--- a/main.py
+++ b/main.py
@@ -55,7 +55,7 @@ from src.utils.check.check_ffmpeg_installed     import check_ffmpeg_installed
 from src.utils.validate_anime_sama_url          import validate_anime_sama_url
 from src.utils.extract.extract_anime_name       import extract_anime_name
 from src.utils.get.get_save_directory           import get_save_directory, format_save_path
-from src.utils.download.download_episode        import download_episode, create_match_file
+from src.utils.download.download_episode        import download_episode, create_match_file, convert_episode_ts_to_mp4
 from src.utils.fetch.fetch_alt_titles           import fetch_alt_titles
 from src.utils.download.download_episode_with_fallback import download_episode_with_fallback
 from src.utils.search.search_anime              import search_anime
@@ -279,7 +279,7 @@ def process_season(base_url, args, headers, interactive, pause_at_end=True):
     # a fichier unique (Sibnet, Sendvid) - sinon un fallback silencieux vers
     # Sibnet fait perdre tout le gain de vitesse du choix initial.
     def _speed_sort_key(p):
-        return 0 if is_fast_player(p) else 1
+        return 0 if is_fast_player(p, episodes.get(p)) else 1
 
     chosen_lang = _player_lang(player_choice)
     other_players = [p for p in episodes.keys() if p != player_choice]
@@ -293,7 +293,13 @@ def process_season(base_url, args, headers, interactive, pause_at_end=True):
     if not args.no_mal and get_anime_name:
         os.makedirs(save_dir, exist_ok=True)
         alt_names = fetch_alt_titles(base_url, headers=headers)
-        create_match_file(save_dir, get_anime_name, interactive=interactive, alt_names=alt_names)
+        # get_saison_info is "saisonN" (or nakanime's "saisonN") - pull N out
+        # so the MAL search can be season-aware instead of always searching
+        # the bare show name (which silently matches season 1's MAL entry
+        # even when downloading a later season/part, e.g. Fire Force S3).
+        m_season_num = re.search(r'\d+', get_saison_info or "")
+        season_number = int(m_season_num.group()) if m_season_num else None
+        create_match_file(save_dir, get_anime_name, interactive=interactive, alt_names=alt_names, season_number=season_number)
 
     print(f"\n{Colors.BOLD}{Colors.HEADER}🎬 PROCESSING EPISODES{Colors.ENDC}")
     print_separator()
@@ -318,7 +324,13 @@ def process_season(base_url, args, headers, interactive, pause_at_end=True):
             thread_choice = input(f"{Colors.BOLD}Download all episodes simultaneously? (t/1/y = yes / s = no): {Colors.ENDC}").strip().lower()
             use_threading = thread_choice in ['t', 'threaded', '1', 'y', 'yes']
 
-        if any('m3u8' in src for src in video_sources if src):
+        # Only checking the chosen player's own video_sources misses the case
+        # where it fails per-episode and download_episode_with_fallback()
+        # switches to a different (segmented/m3u8) player - the ts-threading
+        # and mp4-conversion questions would then silently never get asked,
+        # even though the fallback player ends up needing them.
+        any_fallback_is_fast = any(is_fast_player(p, episodes.get(p)) for p in player_order)
+        if any_fallback_is_fast or any('m3u8' in src for src in video_sources if src):
             if use_threading:
                 print_status("Using threading with M3U8.", "warning")
 
@@ -345,6 +357,8 @@ def process_season(base_url, args, headers, interactive, pause_at_end=True):
     try:
         if use_threading and len(episode_indices) > 1:
             print_status("Starting threaded downloads...", "info")
+            from src.utils.download.download_video import set_batch_size
+            set_batch_size(len(episode_indices))
             # Once inside a threaded batch, no per-episode question should
             # ever hit the terminal again - the batch-level choices already
             # made (use_ts_threading, automatic_mp4) cover it, and letting
@@ -353,18 +367,63 @@ def process_season(base_url, args, headers, interactive, pause_at_end=True):
             # producing the repeated, garbled "Threaded Download Option"
             # prompts interleaved with progress bars). Forcing
             # interactive=False here makes it silently default instead.
+            # Downloads and conversions are split into two separate phases
+            # instead of each episode converting right after its own
+            # download finishes. Converting mid-batch meant its (occasional
+            # but still live-terminal) output was printed while OTHER
+            # episodes' download bars were still actively redrawing -
+            # mixing those broke the bars' terminal positioning and
+            # produced garbled output. Running every download to
+            # completion first (bars visible throughout, no other prints
+            # happening) then every conversion afterward (bars gone, only
+            # plain text) keeps both phases clean.
+            to_convert = []  # (ep_num, ts_path)
+            # Tried registering tqdm's shared lock in every worker thread
+            # here (tqdm's documented fix for multi-threaded bar corruption)
+            # but it deadlocked once episodes' nested per-segment executor
+            # threads (in download_video.py) also touched that same lock -
+            # reverted. Live-tested and confirmed to hang indefinitely.
             with ThreadPoolExecutor() as executor:
                 future_to_episode = {
-                    executor.submit(download_episode_with_fallback, ep_num, ep_idx, episodes, player_order, get_anime_name, save_dir, video_src, use_ts_threading, automatic_mp4, pre_selected_tool, args.no_mal, False): ep_num
+                    executor.submit(download_episode_with_fallback, ep_num, ep_idx, episodes, player_order, get_anime_name, save_dir, video_src, use_ts_threading, automatic_mp4, pre_selected_tool, args.no_mal, False, automatic_mp4): ep_num
                     for ep_num, ep_idx, video_src in zip(episode_numbers, episode_indices, video_sources)
                 }
                 for future in as_completed(future_to_episode):
                     ep_num = future_to_episode[future]
                     try:
-                        success, _ = future.result()
-                        if not success: failed_downloads += 1
+                        success, output_path = future.result()
+                        if not success:
+                            failed_downloads += 1
+                        elif automatic_mp4 and output_path and output_path.endswith('.ts'):
+                            to_convert.append((ep_num, output_path))
                     except Exception as e:
                         print_status(f"Error ep {ep_num}: {e}", "error")
+                        failed_downloads += 1
+
+            total_episodes = len(episode_indices)
+            downloaded_count = total_episodes - failed_downloads
+            print_status(f"✅ {downloaded_count}/{total_episodes} episode(s) downloaded", "success")
+
+            if to_convert:
+                print_separator()
+                print_status(f"🎬 Conversion .ts → .mp4 ({len(to_convert)} episode(s))", "info")
+                print_separator()
+                # Live-tested: converting these files one at a time takes
+                # ~8-9s each, but running several PyAV conversions
+                # concurrently made the whole batch take 10+ minutes with
+                # almost no CPU progress. Each conversion reads its whole
+                # multi-hundred-MB .ts file via av.open() with a large
+                # probesize/analyzeduration - several of those happening at
+                # once thrashes a spinning disk into near-random-access
+                # territory instead of the fast sequential read a single
+                # conversion gets, which dwarfs any benefit from
+                # parallelism. Converting sequentially instead.
+                for ep_num, ts_path in to_convert:
+                    try:
+                        success, _ = convert_episode_ts_to_mp4(ep_num, ts_path, pre_selected_tool)
+                        if not success: failed_downloads += 1
+                    except Exception as e:
+                        print_status(f"Error converting ep {ep_num}: {e}", "error")
                         failed_downloads += 1
         else:
             for episode_num, ep_idx, video_source in zip(episode_numbers, episode_indices, video_sources):

--- a/main.py
+++ b/main.py
@@ -102,15 +102,22 @@ def parse_selection_indices(user_input, count):
     return indices
 
 
-def process_season(base_url, args, headers, interactive, pause_at_end=True):
+def plan_season(base_url, args, headers, interactive):
+    """Asks every interactive question for one season (player, episodes,
+    save path, threading/mp4 choices) and returns a plan dict ready for
+    execute_season_plan() - without downloading anything yet. Split out of
+    the old process_season() so a multi-season run can gather every
+    season's answers upfront, then run all the downloads back to back with
+    no further prompts. Returns None on failure/cancellation, or
+    {"already_done": True} for URLs handled synchronously (scans)."""
     is_valid, error_msg = validate_anime_sama_url(base_url)
     if not is_valid:
         print_status(error_msg, "error")
-        return 1
+        return None
 
     if "/scan" in base_url.lower():
         download_scan(base_url, headers)
-        return 0
+        return {"already_done": True}
 
     anime_name = extract_anime_name(base_url)
     print_status(f"Detected anime: {anime_name}", "info")
@@ -145,7 +152,7 @@ def process_season(base_url, args, headers, interactive, pause_at_end=True):
     episodes = fetch_episodes(base_url, headers=headers, wanted_episodes=wanted_episodes)
     if not episodes:
         print_status("Failed to fetch episodes.", "error")
-        return 1
+        return None
 
     print_episodes(episodes, wanted_episodes=wanted_episodes)
 
@@ -186,12 +193,12 @@ def process_season(base_url, args, headers, interactive, pause_at_end=True):
 
         if not player_choice:
             print_status(f"Player '{args.player}' not found.", "error")
-            return 1
+            return None
     else:
         player_choice = get_player_choice(episodes, wanted_episodes=wanted_episodes)
 
     if not player_choice:
-        return 1
+        return None
 
     episode_indices = None
 
@@ -203,9 +210,9 @@ def process_season(base_url, args, headers, interactive, pause_at_end=True):
                 print_status(f"Latest episode selected: Episode {count}", "info")
             else:
                 print_status("No episodes found to select latest.", "error")
-                return 1
+                return None
         else:
-            return 1
+            return None
 
     if not episode_indices:
         if args.episodes:
@@ -224,13 +231,13 @@ def process_season(base_url, args, headers, interactive, pause_at_end=True):
                 episode_indices = parse_selection_indices(args.episodes, len(episodes[player_choice]))
                 if not episode_indices:
                     print_status("Invalid episode list format", "error")
-                    return 1
+                    return None
         else:
              if not args.latest:
                 episode_indices = get_episode_choice(episodes, player_choice)
 
     if episode_indices is None or not episode_indices:
-        return 1
+        return None
 
     get_anime_name = extract_anime_name(base_url)
     if 'nakanime.tv' in base_url.lower() or 'nakanime.fr' in base_url.lower():
@@ -266,7 +273,7 @@ def process_season(base_url, args, headers, interactive, pause_at_end=True):
 
     if not episode_indices:
         print_status("No available episodes to download for this player.", "error")
-        return 1
+        return None
 
     urls = [episodes[player_choice][index] for index in episode_indices]
     episode_numbers = [index + 1 for index in episode_indices]
@@ -290,16 +297,18 @@ def process_season(base_url, args, headers, interactive, pause_at_end=True):
     else:
         player_order = [player_choice] + sorted(other_players, key=_speed_sort_key)
 
+    # get_saison_info is "saisonN" (or nakanime's "saisonN") - pull N out so
+    # both the MAL search and the SxxExx episode filenames are season-aware
+    # instead of always assuming season 1.
+    m_season_num = re.search(r'\d+', get_saison_info or "")
+    season_number = int(m_season_num.group()) if m_season_num else None
+
     if not args.no_mal and get_anime_name:
         os.makedirs(save_dir, exist_ok=True)
         alt_names = fetch_alt_titles(base_url, headers=headers)
-        # get_saison_info is "saisonN" (or nakanime's "saisonN") - pull N out
-        # so the MAL search can be season-aware instead of always searching
-        # the bare show name (which silently matches season 1's MAL entry
-        # even when downloading a later season/part, e.g. Fire Force S3).
-        m_season_num = re.search(r'\d+', get_saison_info or "")
-        season_number = int(m_season_num.group()) if m_season_num else None
-        create_match_file(save_dir, get_anime_name, interactive=interactive, alt_names=alt_names, season_number=season_number)
+        # May rename save_dir (tvdb/imdb identification mode tags the folder
+        # name) - every download below must use the returned path.
+        save_dir = create_match_file(save_dir, get_anime_name, interactive=interactive, alt_names=alt_names, season_number=season_number)
 
     print(f"\n{Colors.BOLD}{Colors.HEADER}🎬 PROCESSING EPISODES{Colors.ENDC}")
     print_separator()
@@ -309,7 +318,7 @@ def process_season(base_url, args, headers, interactive, pause_at_end=True):
     video_sources = fetch_video_source(urls)
     if not video_sources:
         print_status("Could not extract video sources", "error")
-        return 1
+        return None
 
     if isinstance(video_sources, str):
         video_sources = [video_sources]
@@ -353,6 +362,46 @@ def process_season(base_url, args, headers, interactive, pause_at_end=True):
                                 pre_selected_tool = 'ffmpeg'
                                 break
 
+    return {
+        "episodes": episodes,
+        "player_choice": player_choice,
+        "episode_indices": episode_indices,
+        "urls": urls,
+        "episode_numbers": episode_numbers,
+        "player_order": player_order,
+        "get_anime_name": get_anime_name,
+        "save_dir": save_dir,
+        "video_sources": video_sources,
+        "use_threading": use_threading,
+        "use_ts_threading": use_ts_threading,
+        "automatic_mp4": automatic_mp4,
+        "pre_selected_tool": pre_selected_tool,
+        "season_number": season_number,
+        "args": args,
+        "interactive": interactive,
+    }
+
+
+def execute_season_plan(plan, pause_at_end=True):
+    """Runs the actual downloads for one season, given a plan already built
+    by plan_season() - no interactive questions from here on."""
+    episodes = plan["episodes"]
+    player_choice = plan["player_choice"]
+    episode_indices = plan["episode_indices"]
+    urls = plan["urls"]
+    episode_numbers = plan["episode_numbers"]
+    player_order = plan["player_order"]
+    get_anime_name = plan["get_anime_name"]
+    save_dir = plan["save_dir"]
+    video_sources = plan["video_sources"]
+    use_threading = plan["use_threading"]
+    use_ts_threading = plan["use_ts_threading"]
+    automatic_mp4 = plan["automatic_mp4"]
+    pre_selected_tool = plan["pre_selected_tool"]
+    season_number = plan["season_number"]
+    args = plan["args"]
+    interactive = plan["interactive"]
+
     failed_downloads = 0
     try:
         if use_threading and len(episode_indices) > 1:
@@ -385,7 +434,7 @@ def process_season(base_url, args, headers, interactive, pause_at_end=True):
             # reverted. Live-tested and confirmed to hang indefinitely.
             with ThreadPoolExecutor() as executor:
                 future_to_episode = {
-                    executor.submit(download_episode_with_fallback, ep_num, ep_idx, episodes, player_order, get_anime_name, save_dir, video_src, use_ts_threading, automatic_mp4, pre_selected_tool, args.no_mal, False, automatic_mp4): ep_num
+                    executor.submit(download_episode_with_fallback, ep_num, ep_idx, episodes, player_order, get_anime_name, save_dir, video_src, use_ts_threading, automatic_mp4, pre_selected_tool, args.no_mal, False, automatic_mp4, season_number): ep_num
                     for ep_num, ep_idx, video_src in zip(episode_numbers, episode_indices, video_sources)
                 }
                 for future in as_completed(future_to_episode):
@@ -427,7 +476,7 @@ def process_season(base_url, args, headers, interactive, pause_at_end=True):
                         failed_downloads += 1
         else:
             for episode_num, ep_idx, video_source in zip(episode_numbers, episode_indices, video_sources):
-                success, _ = download_episode_with_fallback(episode_num, ep_idx, episodes, player_order, get_anime_name, save_dir, video_source, use_ts_threading, automatic_mp4, pre_selected_tool, args.no_mal, interactive)
+                success, _ = download_episode_with_fallback(episode_num, ep_idx, episodes, player_order, get_anime_name, save_dir, video_source, use_ts_threading, automatic_mp4, pre_selected_tool, args.no_mal, interactive, season_number=season_number)
                 if not success: failed_downloads += 1
 
         print_separator()
@@ -446,6 +495,18 @@ def process_season(base_url, args, headers, interactive, pause_at_end=True):
     except Exception as e:
         print_status(f"Error: {e}", "error")
         return 1
+
+
+def process_season(base_url, args, headers, interactive, pause_at_end=True):
+    """Single-season convenience wrapper: plan then immediately execute -
+    same behavior as before the plan/execute split, for callers that only
+    ever handle one season at a time."""
+    plan = plan_season(base_url, args, headers, interactive)
+    if plan is None:
+        return 1
+    if plan.get("already_done"):
+        return 0
+    return execute_season_plan(plan, pause_at_end=pause_at_end)
 
 
 def main():
@@ -671,14 +732,40 @@ def main():
 
         multi = len(season_urls) > 1
         overall_rc = 0
+
+        if not multi:
+            rc = process_season(season_urls[0], args, headers, interactive, pause_at_end=True)
+            return rc if rc != 0 else 0
+
+        # Multi-season: gather every season's answers (player, episodes,
+        # save path, threading/mp4 choices) up front, THEN run every
+        # season's downloads back to back with no further prompts - instead
+        # of interleaving "ask questions" and "download" per season, which
+        # meant coming back every few minutes to answer the next season's
+        # questions.
+        print(f"\n{Colors.BOLD}{Colors.HEADER}=== Configuring {len(season_urls)} seasons ==={Colors.ENDC}")
+        plans = []
         for i, season_url in enumerate(season_urls):
-            if multi:
-                print(f"\n{Colors.BOLD}{Colors.HEADER}=== Saison {i + 1}/{len(season_urls)} ==={Colors.ENDC}")
-            rc = process_season(season_url, args, headers, interactive, pause_at_end=not multi)
+            print(f"\n{Colors.BOLD}{Colors.HEADER}--- Season {i + 1}/{len(season_urls)} configuration ---{Colors.ENDC}")
+            plan = plan_season(season_url, args, headers, interactive)
+            if plan is None:
+                overall_rc = 1
+                continue
+            plans.append(plan)
+
+        if not plans:
+            return 1
+
+        print(f"\n{Colors.BOLD}{Colors.HEADER}=== All seasons configured - starting downloads ==={Colors.ENDC}")
+        for i, plan in enumerate(plans):
+            print(f"\n{Colors.BOLD}{Colors.HEADER}=== Season {i + 1}/{len(plans)} download ==={Colors.ENDC}")
+            if plan.get("already_done"):
+                continue
+            rc = execute_season_plan(plan, pause_at_end=False)
             if rc != 0:
                 overall_rc = 1
 
-        if multi and interactive:
+        if interactive:
             input(f"{Colors.BOLD}Press Enter to exit...{Colors.ENDC}")
 
         return overall_rc

--- a/src/utils/config/config.json
+++ b/src/utils/config/config.json
@@ -1,6 +1,0 @@
-{
-    "cf_clearance_cookie": "",
-    "headers": {
-        "User-Agent": ""
-    }
-}

--- a/src/utils/download/download_episode.py
+++ b/src/utils/download/download_episode.py
@@ -601,10 +601,14 @@ def _tag_dir_with_external_id(save_dir, anime_name, interactive):
 
 def create_match_file(save_dir, anime_name, interactive=True, alt_names=None, season_number=None):
     """Identifies save_dir to Plex, either via a MyAnimeList .match file or
-    (per the 'identification_mode' setting) an external-id folder tag.
-    Returns the directory to use for saving this episode's file - callers
-    must use the returned value, since tagging can rename save_dir."""
+    (per the 'identification_mode' setting) an external-id folder tag, or
+    does nothing at all if the mode is 'none'. Returns the directory to use
+    for saving this episode's file - callers must use the returned value,
+    since tagging can rename save_dir."""
     identification_mode = get_setting('identification_mode', 'mal')
+
+    if identification_mode == "none":
+        return save_dir
 
     if identification_mode == "external":
         if not anime_name:

--- a/src/utils/download/download_episode.py
+++ b/src/utils/download/download_episode.py
@@ -7,11 +7,127 @@ from src.var                            import print_separator, print_status, Co
 from src.utils.download.download_video  import download_video
 from src.utils.ts.convert_ts_to_mp4     import convert_ts_to_mp4
 from src.utils.download.verify_video_file import verify_or_warn
+from src.utils.config.config            import get_setting
 import time
+
+# Caches which season directories have already been tagged with an external
+# id this run, so a threaded batch (many episodes of the same season) only
+# prompts once instead of once per episode - same pattern as _mal_search_cache.
+_external_id_cache = {}
+_external_id_cache_lock = threading.Lock()
 
 PREFIX_URL = "https://myanimelist.net/search/prefix.json"
 TENRAI_EPISODES_URL = "https://api.tenrai.org/v1/anime/{id}/episodes?page={page}"
 TENRAI_DETAILS_URL = "https://api.tenrai.org/v1/anime/{id}"
+
+# IMDb's own site uses this endpoint for its search-box autocomplete - no
+# API key needed, unlike TheTVDB (whose real search API requires auth with
+# no free keyless equivalent). Returns JSONP: "imdb$query({...json...})".
+IMDB_SUGGEST_URL = "https://sg.media-imdb.com/suggests/{first_letter}/{query}.json"
+
+
+def _search_imdb(query, timeout=10):
+    """Search IMDb's keyless autocomplete endpoint. Returns a list of
+    {id, title, year, type} candidates (TV series preferred first), or []
+    on failure/no results."""
+    import json as _json
+    slug = re.sub(r'[^a-z0-9]+', '_', query.lower()).strip('_')
+    if not slug:
+        return []
+    first_letter = slug[0]
+    url = IMDB_SUGGEST_URL.format(first_letter=first_letter, query=slug)
+    try:
+        resp = requests.get(url, timeout=timeout, headers={"User-Agent": "Mozilla/5.0"})
+        resp.raise_for_status()
+        # Strip the "imdb$query(...)" JSONP wrapper to get raw JSON. The
+        # prefix isn't reliably \w-only - it can echo the query with literal
+        # "%20"/other punctuation in it (e.g. "imdb$saga_of%20tanya..."), so
+        # match on the first "(" / last ")" instead of anchoring the prefix.
+        text = resp.text.strip()
+        start, end = text.find('('), text.rfind(')')
+        if start == -1 or end == -1 or end <= start:
+            return []
+        data = _json.loads(text[start + 1:end])
+        candidates = []
+        for item in data.get("d", []):
+            if "id" not in item or not item["id"].startswith("tt"):
+                continue  # skip person (nm...) entries
+            candidates.append({
+                "id": item["id"],
+                "title": item.get("l", "?"),
+                "year": item.get("y") or item.get("yr", ""),
+                "type": item.get("q", ""),
+            })
+        # TV series (incl. mini-series) first - most relevant for anime.
+        candidates.sort(key=lambda c: 0 if "series" in c["type"].lower() else 1)
+        return candidates
+    except Exception:
+        return []
+
+
+# TheTVDB v4 API - unlike IMDb's suggest endpoint, this genuinely requires a
+# free API key (register at https://thetvdb.com/api-information to get one,
+# then set it in Settings > Change Plex Identification Method). The key
+# itself is exchanged for a short-lived bearer token via /login, cached here
+# for the rest of the run so we don't re-login on every search.
+TVDB_LOGIN_URL = "https://api4.thetvdb.com/v4/login"
+TVDB_SEARCH_URL = "https://api4.thetvdb.com/v4/search"
+
+_tvdb_token = None
+_tvdb_token_lock = threading.Lock()
+
+
+def _get_tvdb_token(api_key, timeout=10):
+    global _tvdb_token
+    with _tvdb_token_lock:
+        if _tvdb_token:
+            return _tvdb_token
+        try:
+            resp = requests.post(TVDB_LOGIN_URL, json={"apikey": api_key}, timeout=timeout)
+            resp.raise_for_status()
+            _tvdb_token = resp.json()["data"]["token"]
+            return _tvdb_token
+        except Exception as e:
+            print_status(f"TVDB login failed (check your API key in Settings): {e}", "error")
+            return None
+
+
+def _search_tvdb(query, timeout=10):
+    """Search TheTVDB v4 API. Requires a free API key configured via
+    Settings (get one at https://thetvdb.com/api-information). Returns a
+    list of {id, title, year, type} candidates, or [] on failure/no key."""
+    api_key = get_setting("tvdb_api_key")
+    if not api_key:
+        return []
+    token = _get_tvdb_token(api_key)
+    if not token:
+        return []
+    try:
+        resp = requests.get(
+            TVDB_SEARCH_URL,
+            params={"query": query, "type": "series"},
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=timeout,
+        )
+        resp.raise_for_status()
+        data = resp.json().get("data", [])
+        candidates = []
+        for item in data:
+            # "name" is the show's primary/original-language title (often
+            # Japanese for anime, e.g. "幼女戦記") - prefer the English
+            # translation when TVDB has one, only falling back to "name".
+            eng_title = item.get("translations", {}).get("eng")
+            candidates.append({
+                "id": item.get("tvdb_id") or item.get("id"),
+                "title": eng_title or item.get("name", "?"),
+                "year": item.get("year", ""),
+                "type": item.get("type", "series"),
+            })
+        return candidates
+    except Exception as e:
+        print_status(f"TVDB search failed: {e}", "error")
+        return []
+
 
 _mal_search_cache = {}
 _cache_lock = threading.Lock()
@@ -368,21 +484,149 @@ def search_anime_on_mal(anime_name, interactive=True, alt_names=None, season_num
         _mal_search_cache[cache_key] = result
         return result
 
+_TAG_PATTERN = re.compile(r'\s*\[(tvdb|imdbid)-[\w]+\]\s*$')
+_VALID_TAG = re.compile(r'^(tvdb-\w+|imdbid-tt\d+)$', re.IGNORECASE)
+
+
+def _tag_dir_with_external_id(save_dir, anime_name, interactive):
+    """Identify the show to Plex's TheTVDB/IMDb-based agents by appending a
+    "[tvdb-XXXX]" or "[imdbid-ttXXXXXXX]" tag to the SHOW's root folder name
+    (save_dir's parent - not the season subfolder itself), instead of
+    writing a MyAnimeList .match file. Those agents assign one identity per
+    show, derived from the top-level folder, same as MyAnimeList.bundle's
+    own .match resolution - tagging a season subfolder instead would do
+    nothing. TVDB and IMDb are one combined "external" mode - which one
+    applies is picked per-anime at the prompt (typing the tag directly)
+    rather than as a separate persistent setting.
+    Returns the season directory to keep using for this episode's save path
+    (adjusted to sit under the renamed root, if a rename happened)."""
+    root_cache_key = (anime_name or "").lower().strip()
+    season_basename = os.path.basename(save_dir.rstrip("\\/"))
+    root_dir = os.path.dirname(save_dir.rstrip("\\/"))
+
+    with _external_id_cache_lock:
+        if root_cache_key in _external_id_cache:
+            new_root = _external_id_cache[root_cache_key]
+            return os.path.join(new_root, season_basename)
+
+        root_basename = os.path.basename(root_dir)
+        if _TAG_PATTERN.search(root_basename):
+            _external_id_cache[root_cache_key] = root_dir
+            return save_dir
+
+        if not interactive:
+            print_status(
+                f"Non-interactive run: skipping id tagging for '{anime_name}' "
+                f"(rename the show's root folder by hand with a [tvdb-XXXX] or [imdbid-ttXXXXXXX] suffix, "
+                f"or run interactively once).",
+                "warning",
+            )
+            _external_id_cache[root_cache_key] = root_dir
+            return save_dir
+
+        print_separator()
+        has_tvdb_key = bool(get_setting("tvdb_api_key"))
+
+        tvdb_candidates = []
+        if has_tvdb_key:
+            print_status(f"Searching TVDB for: {anime_name}", "info")
+            tvdb_candidates = [dict(c, source="tvdb") for c in _search_tvdb(anime_name)]
+
+        print_status(f"Searching IMDb for: {anime_name}", "info")
+        imdb_candidates = [dict(c, source="imdb") for c in _search_imdb(anime_name)]
+
+        candidates = tvdb_candidates + imdb_candidates
+
+        raw_tag = ""
+        if candidates:
+            print(f"{Colors.BOLD}{Colors.HEADER}Results for '{anime_name}':{Colors.ENDC}")
+            for i, c in enumerate(candidates[:15]):
+                year_str = f", {c['year']}" if c['year'] else ""
+                src_label = "TVDB" if c["source"] == "tvdb" else "IMDb"
+                print(f"{Colors.OKCYAN}  [{i}] {c['title']} ({c['type']}{year_str}) - {src_label} {c['id']}{Colors.ENDC}")
+            try:
+                choice = input(
+                    f"{Colors.BOLD}Select index, or type a tag directly ('tvdb-XXXX'/'imdbid-ttXXXXXXX'), "
+                    f"or blank to skip: {Colors.ENDC}"
+                ).strip()
+            except EOFError:
+                choice = ""
+            if choice.isdigit() and 0 <= int(choice) < len(candidates[:15]):
+                picked = candidates[int(choice)]
+                raw_tag = f"tvdb-{picked['id']}" if picked["source"] == "tvdb" else f"imdbid-{picked['id']}"
+            else:
+                raw_tag = choice
+        else:
+            hint = "" if has_tvdb_key else " (add a free TVDB API key in Settings for TVDB results too)"
+            print_status(f"No results found{hint} - type a tag manually.", "warning")
+            try:
+                raw_tag = input(
+                    f"{Colors.BOLD}Enter tag for '{anime_name}' - "
+                    f"'tvdb-XXXX' or 'imdbid-ttXXXXXXX' (blank to skip): {Colors.ENDC}"
+                ).strip()
+            except EOFError:
+                raw_tag = ""
+
+        if not raw_tag:
+            print_status(f"No tag given, leaving folder untagged for '{anime_name}'", "warning")
+            _external_id_cache[root_cache_key] = root_dir
+            return save_dir
+
+        if not _VALID_TAG.match(raw_tag):
+            print_status(
+                f"'{raw_tag}' doesn't look like 'tvdb-XXXX' or 'imdbid-ttXXXXXXX' - leaving folder untagged.",
+                "error",
+            )
+            _external_id_cache[root_cache_key] = root_dir
+            return save_dir
+
+        grandparent = os.path.dirname(root_dir)
+        new_root = os.path.join(grandparent, f"{root_basename} [{raw_tag}]")
+
+        try:
+            if os.path.exists(root_dir) and not os.path.exists(new_root):
+                # Renaming the show's root moves its whole season subtree
+                # with it - save_dir doesn't need moving separately.
+                os.rename(root_dir, new_root)
+            else:
+                os.makedirs(new_root, exist_ok=True)
+            print_status(f"Tagged show directory: {new_root}", "success")
+            _external_id_cache[root_cache_key] = new_root
+            return os.path.join(new_root, season_basename)
+        except Exception as e:
+            print_status(f"Failed to tag directory: {e}", "error")
+            _external_id_cache[root_cache_key] = root_dir
+            return save_dir
+
+
 def create_match_file(save_dir, anime_name, interactive=True, alt_names=None, season_number=None):
+    """Identifies save_dir to Plex, either via a MyAnimeList .match file or
+    (per the 'identification_mode' setting) an external-id folder tag.
+    Returns the directory to use for saving this episode's file - callers
+    must use the returned value, since tagging can rename save_dir."""
+    identification_mode = get_setting('identification_mode', 'mal')
+
+    if identification_mode == "external":
+        if not anime_name:
+            print_status("Cannot tag directory: anime_name is empty", "error")
+            return save_dir
+        return _tag_dir_with_external_id(save_dir, anime_name, interactive)
+
+    cache_key = f"{(anime_name or '').lower().strip()}::s{season_number or 1}"
+
     with _cache_lock:
         try:
             if not anime_name:
                 print_status("Cannot create match file: anime_name is empty", "error")
-                return
+                return save_dir
 
             match_file_path = os.path.join(save_dir, '.match')
-            cache_key = f"{anime_name.lower().strip()}::s{season_number or 1}"
-            
+
             if cache_key in _mal_search_cache:
                 if cache_key not in _mal_cache_hit_announced:
                     _mal_cache_hit_announced.add(cache_key)
                     print_status(f"Using cached MAL data (already in memory)", "info")
-                return
+                return save_dir
             
             # Multi-part case leaves save_dir itself without a .match (files
             # get manually sorted into the sibling "Part" folders instead) -
@@ -391,7 +635,7 @@ def create_match_file(save_dir, anime_name, interactive=True, alt_names=None, se
                 if cache_key not in _mal_cache_hit_announced:
                     _mal_cache_hit_announced.add(cache_key)
                     print_status(f"Multi-part match folders already exist for: {save_dir}", "info")
-                return
+                return save_dir
 
             if os.path.exists(match_file_path):
                 print_status(f"Match file already exists: {match_file_path}", "info")
@@ -421,8 +665,8 @@ def create_match_file(save_dir, anime_name, interactive=True, alt_names=None, se
                 except Exception as e:
                     print_status(f"Could not read existing match file: {e}", "warning")
                     _mal_search_cache[cache_key] = None
-                
-                return
+
+                return save_dir
             
             print_separator()
             print(f"{Colors.BOLD}{Colors.HEADER}🔍 Searching for anime on MyAnimeList...{Colors.ENDC}")
@@ -448,7 +692,7 @@ def create_match_file(save_dir, anime_name, interactive=True, alt_names=None, se
                     "warning",
                 )
                 print_separator()
-                return
+                return save_dir
 
             if mal_data:
                 with open(match_file_path, 'w', encoding='utf-8') as match_file:
@@ -470,9 +714,12 @@ def create_match_file(save_dir, anime_name, interactive=True, alt_names=None, se
                 print_status(f"Match file created with default values: {match_file_path}", "warning")
                 print_status(f"Could not find or match anime on MAL", "warning")
                 print_separator()
-                
+
+            return save_dir
+
         except Exception as e:
             print_status(f"Error creating match file: {str(e)}", "error")
+            return save_dir
 
 
 def convert_episode_ts_to_mp4(episode_num, ts_path, pre_selected_tool=None):
@@ -485,18 +732,24 @@ def convert_episode_ts_to_mp4(episode_num, ts_path, pre_selected_tool=None):
         print_status(f"Conversion failed for episode {episode_num}, keeping .ts file: {ts_path}", "error")
         return False, ts_path
 
+    # Verify the .mp4 BEFORE deleting the .ts - if conversion silently
+    # produced a corrupted file (seen with "Invalid data found when
+    # processing input"), the .ts is still the only good copy and must not
+    # be thrown away.
+    if not verify_or_warn(final_path, episode_num):
+        print_status(f"Keeping .ts file for episode {episode_num} since the .mp4 failed verification: {ts_path}", "warning")
+        return False, final_path
+
     try:
         os.remove(ts_path)
         removed_note = f"\n{Colors.OKBLUE}ℹ️ Removed temporary .ts file: {ts_path}{Colors.ENDC}"
     except Exception as e:
         removed_note = f"\n{Colors.WARNING}⚠️ Could not remove temporary .ts file: {str(e)}{Colors.ENDC}"
     tqdm.write(f"{Colors.OKGREEN}✅ Episode {episode_num} successfully saved to: {final_path}{Colors.ENDC}{removed_note}")
-    if not verify_or_warn(final_path, episode_num):
-        return False, final_path
     return True, final_path
 
 
-def download_episode(episode_num, url, video_source, anime_name, save_dir, use_ts_threading=False, automatic_mp4=False, pre_selected_tool=None, no_mal=False, interactive=True, defer_conversion=False):
+def download_episode(episode_num, url, video_source, anime_name, save_dir, use_ts_threading=False, automatic_mp4=False, pre_selected_tool=None, no_mal=False, interactive=True, defer_conversion=False, season_number=None):
     if not video_source:
         print_status(f"Could not extract video source for episode {episode_num}", "error")
         return False, None
@@ -509,9 +762,27 @@ def download_episode(episode_num, url, video_source, anime_name, save_dir, use_t
     elif not anime_name:
         print_status("anime_name is empty, skipping MAL matching", "warning")
     else:
-        create_match_file(season_dir, anime_name, interactive=interactive)
+        # create_match_file() can rename season_dir (tagging it with a
+        # [tvdb-XXXX]/[imdbid-XXXX] folder tag in tvdb/imdb identification
+        # mode) - use its returned path for everything from here on so the
+        # actual video file lands in the (possibly renamed) directory.
+        season_dir = create_match_file(season_dir, anime_name, interactive=interactive)
 
-    save_path = os.path.join(season_dir, f"{anime_name if anime_name else 'episode'}_{episode_num}.mp4")
+    # SxxExx naming instead of the old generic "{anime}_{N}.mp4" - Plex's
+    # own scanner and Sonarr both need that pattern to reliably recognize
+    # episode numbers; the generic form was silently going undetected for a
+    # large chunk of the library (bulk-fixed by hand once already).
+    try:
+        episode_int = int(episode_num)
+    except (TypeError, ValueError):
+        episode_int = None
+    season_int = season_number if season_number else 1
+    safe_anime_name = re.sub(r'[:"/\\|?*<>]', '', anime_name) if anime_name else 'episode'
+    if episode_int is not None:
+        filename = f"{safe_anime_name} - S{season_int:02d}E{episode_int:02d}.mp4"
+    else:
+        filename = f"{safe_anime_name}_{episode_num}.mp4"
+    save_path = os.path.join(season_dir, filename)
 
     # Batched into a single print() call: when several episodes download in
     # parallel threads, each separate print()/print_status() call is its own

--- a/src/utils/download/download_episode.py
+++ b/src/utils/download/download_episode.py
@@ -2,12 +2,16 @@ import os
 import re
 import requests
 import threading
+from tqdm                               import tqdm
 from src.var                            import print_separator, print_status, Colors
 from src.utils.download.download_video  import download_video
 from src.utils.ts.convert_ts_to_mp4     import convert_ts_to_mp4
+from src.utils.download.verify_video_file import verify_or_warn
 import time
 
 PREFIX_URL = "https://myanimelist.net/search/prefix.json"
+TENRAI_EPISODES_URL = "https://api.tenrai.org/v1/anime/{id}/episodes?page={page}"
+TENRAI_DETAILS_URL = "https://api.tenrai.org/v1/anime/{id}"
 
 _mal_search_cache = {}
 _cache_lock = threading.Lock()
@@ -15,6 +19,65 @@ _cache_lock = threading.Lock()
 # message for, so a multi-threaded batch download doesn't print it once
 # per episode (it was flooding the interleaved progress bars).
 _mal_cache_hit_announced = set()
+
+
+def _fetch_mal_english_title(mal_id, timeout=10):
+    """English title for a MAL entry, so the candidate picker isn't showing
+    romaji-only names ("Enen no Shouboutai") to someone who doesn't read
+    Japanese - falls back to None (caller just shows the romaji name alone)
+    if the lookup fails or there's no English title on MAL for this entry."""
+    try:
+        resp = requests.get(TENRAI_DETAILS_URL.format(id=mal_id), timeout=timeout)
+        resp.raise_for_status()
+        data = resp.json()
+    except (requests.RequestException, ValueError):
+        return None
+    return (data.get("data") or {}).get("title_english") or None
+
+
+def _fetch_mal_episode_count(mal_id, timeout=15, max_pages=10):
+    """Total episode count for a MAL entry, via the same Tenrai API the Plex
+    plugin uses - needed to tell the user exactly where to split files
+    between multiple MAL entries covering one downloaded season (e.g. a
+    "Part 1" + "Part 2" pair on MAL for one season on the source site)."""
+    total = 0
+    page = 1
+    while page <= max_pages:
+        try:
+            resp = requests.get(TENRAI_EPISODES_URL.format(id=mal_id, page=page), timeout=timeout)
+            resp.raise_for_status()
+            data = resp.json()
+        except (requests.RequestException, ValueError):
+            return total if total else None
+
+        items = data.get("data") or []
+        total += len(items)
+
+        pagination = data.get("pagination") or {}
+        if not pagination.get("has_next_page"):
+            break
+        page += 1
+
+    return total or None
+
+
+_MONTH_NUM = {
+    "jan": 1, "feb": 2, "mar": 3, "apr": 4, "may": 5, "jun": 6,
+    "jul": 7, "aug": 8, "sep": 9, "oct": 10, "nov": 11, "dec": 12,
+}
+
+
+def _air_date_sort_key(item):
+    """(year, month, day) for a MAL search result, oldest first - used to
+    order multi-part picks by real air date instead of selection order."""
+    payload = item.get("payload", {}) or {}
+    aired = payload.get("aired") or ""
+    m = re.match(r"(\w{3})\s+(\d{1,2}),\s*(\d{4})", aired)
+    if m:
+        month = _MONTH_NUM.get(m.group(1).lower()[:3], 0)
+        return (int(m.group(3)), month, int(m.group(2)))
+    start_year = payload.get("start_year") or 0
+    return (start_year, 0, 0)
 
 
 def normalize(text):
@@ -103,15 +166,51 @@ def _auto_select_by_es_score(results, gap_ratio=2.0):
     return None
 
 
-def search_anime_on_mal(anime_name, interactive=True, alt_names=None):
-    cache_key = anime_name.lower().strip()
+_ORDINAL_WORDS = {
+    2: "2nd", 3: "3rd", 4: "4th", 5: "5th", 6: "6th", 7: "7th", 8: "8th", 9: "9th", 10: "10th",
+}
+
+
+def _season_query_variants(anime_name, season_number):
+    """Build MAL search queries that are more likely to hit the entry for
+    this specific season/part rather than the base show (season 1).
+
+    MAL has no single naming convention for sequels ("2nd Season", "Season
+    2", "Part 2", a roman numeral, or a completely different subtitle are
+    all common) so this tries the frequent patterns rather than guaranteeing
+    a hit - search_anime_on_mal() still falls back to the plain name after.
+    """
+    if not season_number or season_number <= 1:
+        return []
+    ordinal = _ORDINAL_WORDS.get(season_number, f"{season_number}th")
+    return [
+        f"{anime_name} {ordinal} Season",
+        f"{anime_name} Season {season_number}",
+        f"{anime_name} S{season_number}",
+        f"{anime_name} Part {season_number}",
+        f"{anime_name} {season_number}",
+    ]
+
+
+def search_anime_on_mal(anime_name, interactive=True, alt_names=None, season_number=None):
+    # Season-qualified cache key: downloading "Fire Force" saison1 and then
+    # saison3 must not collide on the same cached MAL entry (season 1's),
+    # which is what silently happened before this was added.
+    cache_key = f"{anime_name.lower().strip()}::s{season_number or 1}"
     if cache_key in _mal_search_cache:
-        print_status(f"Using cached MAL data for: {anime_name}", "info")
+        print_status(f"Using cached MAL data for: {anime_name} (season {season_number or 1})", "info")
         return _mal_search_cache[cache_key]
+
+    is_later_season = bool(season_number and season_number > 1)
+    season_variants = _season_query_variants(anime_name, season_number)
+    season_variant_keys = {v.lower().strip() for v in season_variants}
 
     seen = set()
     queries = []
-    for name in [anime_name] + list(alt_names or []):
+    # For a later season, try the season-qualified query variants FIRST -
+    # an exact match there is a real signal. The bare name (and alt names)
+    # come after, purely as a fallback if none of the variants hit anything.
+    for name in season_variants + [anime_name] + list(alt_names or []):
         key = name.lower().strip()
         if name and key not in seen:
             seen.add(key)
@@ -120,6 +219,9 @@ def search_anime_on_mal(anime_name, interactive=True, alt_names=None):
     all_results = []
     for query in queries:
         print_status(f"Searching MAL for: {query}", "info")
+        # Membership check (not position) so dedup shifting the list can't
+        # mislabel a plain-name/alt-name query as a season-qualified one.
+        query_is_season_variant = is_later_season and query.lower().strip() in season_variant_keys
 
         data = _fetch_prefix_json(query, media_type="anime")
         results = _flatten_categories(data, wanted_type="anime")
@@ -132,26 +234,46 @@ def search_anime_on_mal(anime_name, interactive=True, alt_names=None):
 
         name_normalized = normalize(query)
         for item in tv_series + other_types:
-            if normalize(item.get("name")) == name_normalized:
-                print_status(f"Found exact match: {item['name']}", "success")
-                result = {
-                    "mal_id": item.get("id"),
-                    "title": item.get("name"),
-                    "type": item.get("payload", {}).get("media_type"),
-                }
-                _mal_search_cache[cache_key] = result
-                return result
-
-        auto_match = _auto_select_by_es_score(results)
-        if auto_match:
-            print_status(f"Auto-selected top result: {auto_match['name']}", "success")
+            item_normalized = normalize(item.get("name"))
+            if item_normalized != name_normalized:
+                continue
+            # For a later season, an exact match only means something when
+            # it came from a season-qualified query ("Fire Force 3rd
+            # Season"). An exact match from the bare anime_name OR an
+            # alt_name (which can just as easily be the show's original/
+            # Japanese title, e.g. "Enen no Shouboutai" for "Fire Force" -
+            # still just identifies the base show, season-agnostic) always
+            # points at whatever MAL calls the base entry, i.e. season 1 -
+            # never trust it here regardless of what string it equals.
+            if not query_is_season_variant and is_later_season:
+                continue
+            print_status(f"Found exact match: {item['name']}", "success")
             result = {
-                "mal_id": auto_match.get("id"),
-                "title": auto_match.get("name"),
-                "type": auto_match.get("payload", {}).get("media_type"),
+                "mal_id": item.get("id"),
+                "title": item.get("name"),
+                "type": item.get("payload", {}).get("media_type"),
             }
             _mal_search_cache[cache_key] = result
             return result
+
+        # Auto-select on es_score only for a normal (season 1 / unknown
+        # season) search. For a later season, a fuzzy top-score pick from a
+        # bare-name/alt-name query is exactly the same "just resolves to the
+        # base show" risk as the exact-match case above, and a fuzzy pick
+        # against a season-qualified variant is too unreliable to trust
+        # blindly either (the variant itself is a guess) - so later seasons
+        # always fall through to the candidate picker below instead.
+        if not query_is_season_variant and not is_later_season:
+            auto_match = _auto_select_by_es_score(results)
+            if auto_match:
+                print_status(f"Auto-selected top result: {auto_match['name']}", "success")
+                result = {
+                    "mal_id": auto_match.get("id"),
+                    "title": auto_match.get("name"),
+                    "type": auto_match.get("payload", {}).get("media_type"),
+                }
+                _mal_search_cache[cache_key] = result
+                return result
 
     if not all_results:
         print_status(f"No results found for '{anime_name}'", "warning")
@@ -160,26 +282,79 @@ def search_anime_on_mal(anime_name, interactive=True, alt_names=None):
 
     tv_series = [r for r in all_results if (r.get("payload", {}).get("media_type") or "").lower() in ["tv", "ona"]]
 
-    if interactive:
+    # A wrong auto-pick here means the WHOLE season gets tagged under the
+    # wrong show, so this always asks - even during an otherwise
+    # non-interactive/threaded batch run - rather than silently skipping or
+    # guessing. It only fires once per anime (result gets cached), so it
+    # doesn't turn into a per-episode prompt storm.
+    ask_for_confirmation = interactive or is_later_season
+
+    if ask_for_confirmation:
         candidates = tv_series if tv_series else all_results
-        print_status("No exact match. Candidates:", "info")
+        print_status(
+            f"No confident match for season {season_number or 1}. Candidates:" if is_later_season
+            else "No exact match. Candidates:",
+            "info",
+        )
         for idx, item in enumerate(candidates):
             payload = item.get("payload", {})
-            print(f"  [{idx}] {item['name']} "
+            english_title = _fetch_mal_english_title(item.get("id"))
+            name_display = f"{item['name']} ({english_title})" if english_title and english_title.lower() != item['name'].lower() else item['name']
+            print(f"  [{idx}] {name_display} "
                   f"({payload.get('media_type')}, {payload.get('start_year')}, "
                   f"score {payload.get('score')})")
 
-        choice = input("Select index (or blank to skip): ").strip()
-        if not choice.isdigit() or int(choice) >= len(candidates):
+        try:
+            # Some seasons on the source site cover more than one MAL entry
+            # (e.g. a "Part 1" + "Part 2" pair) - comma-separated indices
+            # picks several candidates instead of just one.
+            choice = input("Select index, or several separated by commas (or blank to skip): ").strip()
+        except EOFError:
+            # No stdin available at all (fully headless/cron run) - can't ask,
+            # so skip rather than crash the whole batch.
+            print_status("No stdin available to confirm - skipping MAL match for this anime", "warning")
             _mal_search_cache[cache_key] = None
             return None
 
-        selected = candidates[int(choice)]
-        result = {
-            "mal_id": selected.get("id"),
-            "title": selected.get("name"),
-            "type": selected.get("payload", {}).get("media_type"),
-        }
+        if not choice:
+            _mal_search_cache[cache_key] = None
+            return None
+
+        raw_indices = [c.strip() for c in choice.split(",") if c.strip()]
+        if not all(c.isdigit() and int(c) < len(candidates) for c in raw_indices):
+            _mal_search_cache[cache_key] = None
+            return None
+
+        selected_items = [candidates[int(c)] for c in raw_indices]
+        if len(selected_items) > 1:
+            # Always order multi-part picks by actual air date rather than
+            # trusting the order the indices were typed in - otherwise a
+            # "3,2" typo silently swaps which folder becomes "Part 1".
+            selected_items.sort(key=_air_date_sort_key)
+
+        if len(selected_items) == 1:
+            selected = selected_items[0]
+            result = {
+                "mal_id": selected.get("id"),
+                "title": selected.get("name"),
+                "type": selected.get("payload", {}).get("media_type"),
+            }
+            _mal_search_cache[cache_key] = result
+            return result
+
+        # Multi-select: fetch each part's real episode count so the caller
+        # can tell the user exactly where to split the downloaded files.
+        parts = []
+        for item in selected_items:
+            mal_id = item.get("id")
+            ep_count = _fetch_mal_episode_count(mal_id)
+            parts.append({
+                "mal_id": mal_id,
+                "title": item.get("name"),
+                "type": item.get("payload", {}).get("media_type"),
+                "episode_count": ep_count,
+            })
+        result = {"parts": parts}
         _mal_search_cache[cache_key] = result
         return result
     else:
@@ -193,15 +368,15 @@ def search_anime_on_mal(anime_name, interactive=True, alt_names=None):
         _mal_search_cache[cache_key] = result
         return result
 
-def create_match_file(save_dir, anime_name, interactive=True, alt_names=None):
+def create_match_file(save_dir, anime_name, interactive=True, alt_names=None, season_number=None):
     with _cache_lock:
         try:
             if not anime_name:
                 print_status("Cannot create match file: anime_name is empty", "error")
                 return
-            
+
             match_file_path = os.path.join(save_dir, '.match')
-            cache_key = anime_name.lower().strip()
+            cache_key = f"{anime_name.lower().strip()}::s{season_number or 1}"
             
             if cache_key in _mal_search_cache:
                 if cache_key not in _mal_cache_hit_announced:
@@ -209,6 +384,15 @@ def create_match_file(save_dir, anime_name, interactive=True, alt_names=None):
                     print_status(f"Using cached MAL data (already in memory)", "info")
                 return
             
+            # Multi-part case leaves save_dir itself without a .match (files
+            # get manually sorted into the sibling "Part" folders instead) -
+            # detect that already-done state via the first part folder.
+            if os.path.exists(os.path.join(f"{save_dir} Part 1", ".match")):
+                if cache_key not in _mal_cache_hit_announced:
+                    _mal_cache_hit_announced.add(cache_key)
+                    print_status(f"Multi-part match folders already exist for: {save_dir}", "info")
+                return
+
             if os.path.exists(match_file_path):
                 print_status(f"Match file already exists: {match_file_path}", "info")
                 
@@ -244,8 +428,28 @@ def create_match_file(save_dir, anime_name, interactive=True, alt_names=None):
             print(f"{Colors.BOLD}{Colors.HEADER}🔍 Searching for anime on MyAnimeList...{Colors.ENDC}")
             print_separator()
             
-            mal_data = search_anime_on_mal(anime_name, interactive=interactive, alt_names=alt_names)
-            
+            mal_data = search_anime_on_mal(anime_name, interactive=interactive, alt_names=alt_names, season_number=season_number)
+
+            if mal_data and "parts" in mal_data:
+                print_separator()
+                print_status(f"Multiple MAL entries selected for this season - creating one folder per part", "success")
+                for i, part in enumerate(mal_data["parts"], start=1):
+                    part_dir = f"{save_dir} Part {i}"
+                    os.makedirs(part_dir, exist_ok=True)
+                    with open(os.path.join(part_dir, ".match"), 'w', encoding='utf-8') as match_file:
+                        match_file.write(f"title: {part['title']}\n")
+                        match_file.write(f"mal-id: {part['mal_id']}\n")
+                    count_str = str(part['episode_count']) if part['episode_count'] else "unknown - check MAL"
+                    print_status(f"  → Part {i}: {part['title']} (mal-id {part['mal_id']}) - {count_str} episodes → {part_dir}", "info")
+                print_separator()
+                print_status(
+                    f"Files downloaded to '{save_dir}' still need to be moved into the Part "
+                    f"folders above by hand, using the episode counts printed for each part.",
+                    "warning",
+                )
+                print_separator()
+                return
+
             if mal_data:
                 with open(match_file_path, 'w', encoding='utf-8') as match_file:
                     match_file.write(f"title: {mal_data['title']}\n")
@@ -271,24 +475,32 @@ def create_match_file(save_dir, anime_name, interactive=True, alt_names=None):
             print_status(f"Error creating match file: {str(e)}", "error")
 
 
-def download_episode(episode_num, url, video_source, anime_name, save_dir, use_ts_threading=False, automatic_mp4=False, pre_selected_tool=None, no_mal=False, interactive=True):
+def convert_episode_ts_to_mp4(episode_num, ts_path, pre_selected_tool=None):
+    """Convert one already-downloaded .ts to .mp4, standalone from
+    download_episode() - used to run the whole batch's conversions as a
+    separate phase after every episode has finished downloading."""
+    final_path = ts_path.replace('.ts', '.mp4')
+    success, final_path = convert_ts_to_mp4(ts_path, final_path, pre_selected_tool)
+    if not success:
+        print_status(f"Conversion failed for episode {episode_num}, keeping .ts file: {ts_path}", "error")
+        return False, ts_path
+
+    try:
+        os.remove(ts_path)
+        removed_note = f"\n{Colors.OKBLUE}ℹ️ Removed temporary .ts file: {ts_path}{Colors.ENDC}"
+    except Exception as e:
+        removed_note = f"\n{Colors.WARNING}⚠️ Could not remove temporary .ts file: {str(e)}{Colors.ENDC}"
+    tqdm.write(f"{Colors.OKGREEN}✅ Episode {episode_num} successfully saved to: {final_path}{Colors.ENDC}{removed_note}")
+    if not verify_or_warn(final_path, episode_num):
+        return False, final_path
+    return True, final_path
+
+
+def download_episode(episode_num, url, video_source, anime_name, save_dir, use_ts_threading=False, automatic_mp4=False, pre_selected_tool=None, no_mal=False, interactive=True, defer_conversion=False):
     if not video_source:
         print_status(f"Could not extract video source for episode {episode_num}", "error")
         return False, None
     
-    # Batched into a single print() call: when several episodes download in
-    # parallel threads, each separate print()/print_status() call is its own
-    # stdout write, so another thread's lines can land in between them -
-    # producing the garbled, out-of-order header blocks seen in threaded
-    # batch runs. One call per block keeps each episode's header intact.
-    sep_line = "─" * 65
-    header = (
-        f"{Colors.OKBLUE}{Colors.BOLD}{sep_line}{Colors.ENDC}\n"
-        f"{Colors.OKBLUE}ℹ️ Processing episode: {episode_num}{Colors.ENDC}\n"
-        f"{Colors.OKBLUE}ℹ️ Source: {url[:60]}...{Colors.ENDC}"
-    )
-    print(header)
-
     season_dir = save_dir
     os.makedirs(season_dir, exist_ok=True)
 
@@ -301,12 +513,24 @@ def download_episode(episode_num, url, video_source, anime_name, save_dir, use_t
 
     save_path = os.path.join(season_dir, f"{anime_name if anime_name else 'episode'}_{episode_num}.mp4")
 
-    download_header = (
-        f"\n{Colors.BOLD}{Colors.HEADER}⬇️ DOWNLOADING EPISODE {episode_num}{Colors.ENDC}\n"
+    # Batched into a single print() call: when several episodes download in
+    # parallel threads, each separate print()/print_status() call is its own
+    # stdout write, so another thread's lines can land in between them -
+    # producing the garbled, out-of-order header blocks seen in threaded
+    # batch runs. One call per block keeps each episode's header intact,
+    # and one opening/closing separator (instead of one per sub-line) keeps
+    # a whole episode's setup info as a single compact block.
+    sep_line = "─" * 65
+    header = (
+        f"{Colors.OKBLUE}{Colors.BOLD}{sep_line}{Colors.ENDC}\n"
+        f"{Colors.OKBLUE}ℹ️ Processing episode: {episode_num}{Colors.ENDC}\n"
+        f"{Colors.OKBLUE}ℹ️ Source: {url[:60]}...{Colors.ENDC}\n"
+        f"{Colors.BOLD}{Colors.HEADER}⬇️ DOWNLOADING EPISODE {episode_num}{Colors.ENDC}\n"
+        f"{Colors.OKCYAN}⏳ Starting download: {os.path.basename(save_path)}{Colors.ENDC}\n"
         f"{Colors.OKBLUE}{Colors.BOLD}{sep_line}{Colors.ENDC}"
     )
-    print(download_header)
-    
+    tqdm.write(header)
+
     try:
         success, output_path = download_video(video_source, save_path, use_ts_threading=use_ts_threading, url=url, automatic_mp4=automatic_mp4, interactive=interactive)
     except Exception as e:
@@ -318,8 +542,17 @@ def download_episode(episode_num, url, video_source, anime_name, save_dir, use_t
         return False, None
     
     if ('m3u8' in video_source or 'LULU_DEFERRED:' in video_source) and output_path and output_path.endswith('.ts'):
-        print(f"{Colors.OKBLUE}{Colors.BOLD}{sep_line}{Colors.ENDC}\n"
-              f"{Colors.OKGREEN}✅ Video saved as {output_path} (MPEG-TS format, playable in VLC or similar players){Colors.ENDC}")
+        if automatic_mp4 and defer_conversion:
+            # Batch mode: conversion happens in a separate phase after every
+            # episode's download has finished. No text is printed here - the
+            # "Combined .../assembled N/M" messages from download_video.py
+            # (deferred and flushed once the whole download phase is done)
+            # already confirm success, and printing anything here would
+            # interleave with OTHER episodes' still-active download bars,
+            # which is what was corrupting the terminal display.
+            return True, output_path
+        tqdm.write(f"{Colors.OKBLUE}{Colors.BOLD}{sep_line}{Colors.ENDC}\n"
+                   f"{Colors.OKGREEN}✅ Video saved as {output_path} (MPEG-TS format, playable in VLC or similar players){Colors.ENDC}")
         if automatic_mp4:
             success, final_path = convert_ts_to_mp4(output_path, save_path, pre_selected_tool)
             if success:
@@ -329,15 +562,21 @@ def download_episode(episode_num, url, video_source, anime_name, save_dir, use_t
                     removed_note = f"\n{Colors.OKBLUE}ℹ️ Removed temporary .ts file: {output_path}{Colors.ENDC}"
                 except Exception as e:
                     removed_note = f"\n{Colors.WARNING}⚠️ Could not remove temporary .ts file: {str(e)}{Colors.ENDC}"
-                print(f"{Colors.OKGREEN}✅ Episode {episode_num} successfully saved to: {final_path}{Colors.ENDC}{removed_note}")
+                tqdm.write(f"{Colors.OKGREEN}✅ Episode {episode_num} successfully saved to: {final_path}{Colors.ENDC}{removed_note}")
+                if not verify_or_warn(final_path, episode_num):
+                    return False, final_path
                 return True, final_path
             else:
                 print_status(f"Conversion failed for episode {episode_num}, keeping .ts file: {output_path}", "error")
                 return False, output_path
         else:
             print_status(f"Keeping .ts file for episode {episode_num}: {output_path}", "info")
+            if not verify_or_warn(output_path, episode_num):
+                return False, output_path
             return True, output_path
     else:
-        print(f"{Colors.OKBLUE}{Colors.BOLD}{sep_line}{Colors.ENDC}\n"
-              f"{Colors.OKGREEN}✅ Episode {episode_num} successfully saved to: {save_path}{Colors.ENDC}")
+        tqdm.write(f"{Colors.OKBLUE}{Colors.BOLD}{sep_line}{Colors.ENDC}\n"
+                   f"{Colors.OKGREEN}✅ Episode {episode_num} successfully saved to: {save_path}{Colors.ENDC}")
+        if not verify_or_warn(save_path, episode_num):
+            return False, save_path
         return True, save_path

--- a/src/utils/download/download_episode_with_fallback.py
+++ b/src/utils/download/download_episode_with_fallback.py
@@ -5,7 +5,8 @@ from src.utils.download.download_episode         import download_episode
 
 def download_episode_with_fallback(episode_num, episode_index, episodes, player_order, anime_name, save_dir,
                                     primary_video_source=None, use_ts_threading=False, automatic_mp4=False,
-                                    pre_selected_tool=None, no_mal=False, interactive=True, defer_conversion=False):
+                                    pre_selected_tool=None, no_mal=False, interactive=True, defer_conversion=False,
+                                    season_number=None):
     for i, player in enumerate(player_order):
         urls_for_player = episodes.get(player)
         if not urls_for_player or episode_index >= len(urls_for_player):
@@ -28,7 +29,7 @@ def download_episode_with_fallback(episode_num, episode_index, episodes, player_
 
         success, output_path = download_episode(episode_num, url, video_source, anime_name, save_dir,
                                                   use_ts_threading, automatic_mp4, pre_selected_tool, no_mal, interactive,
-                                                  defer_conversion=defer_conversion)
+                                                  defer_conversion=defer_conversion, season_number=season_number)
         if success:
             return True, output_path
 

--- a/src/utils/download/download_episode_with_fallback.py
+++ b/src/utils/download/download_episode_with_fallback.py
@@ -5,7 +5,7 @@ from src.utils.download.download_episode         import download_episode
 
 def download_episode_with_fallback(episode_num, episode_index, episodes, player_order, anime_name, save_dir,
                                     primary_video_source=None, use_ts_threading=False, automatic_mp4=False,
-                                    pre_selected_tool=None, no_mal=False, interactive=True):
+                                    pre_selected_tool=None, no_mal=False, interactive=True, defer_conversion=False):
     for i, player in enumerate(player_order):
         urls_for_player = episodes.get(player)
         if not urls_for_player or episode_index >= len(urls_for_player):
@@ -27,7 +27,8 @@ def download_episode_with_fallback(episode_num, episode_index, episodes, player_
             continue
 
         success, output_path = download_episode(episode_num, url, video_source, anime_name, save_dir,
-                                                  use_ts_threading, automatic_mp4, pre_selected_tool, no_mal, interactive)
+                                                  use_ts_threading, automatic_mp4, pre_selected_tool, no_mal, interactive,
+                                                  defer_conversion=defer_conversion)
         if success:
             return True, output_path
 

--- a/src/utils/download/download_video.py
+++ b/src/utils/download/download_video.py
@@ -9,32 +9,46 @@ from concurrent.futures                 import ThreadPoolExecutor, as_completed
 
 from src.var                            import Colors, print_status, DEFAULT_USER_AGENT
 from src.utils.parse.parse_ts_segments  import parse_ts_segments
+from src.utils.tqdm_position             import TqdmPosition as _TqdmPosition
 
-# Assigns each concurrent episode download its own terminal line (tqdm's
-# `position`) instead of letting them all draw over line 0 - without this,
-# several episodes downloading in parallel (batch threaded mode) produce a
-# garbled, overlapping progress display. Positions are released and reused
-# once a download finishes instead of growing unbounded.
-_position_lock = threading.Lock()
-_positions_in_use = set()
+# In batch mode (several episodes downloading in parallel), printing
+# anything per-episode - even one line per completion - while OTHER
+# episodes' download bars are still actively redrawing corrupts the
+# terminal display (the bars' cursor-position math gets thrown off by
+# unrelated output landing mid-redraw, and the bars themselves fight over
+# position at high concurrency regardless). So in batch mode nothing is
+# printed per episode at all, live bars are disabled too, and completion
+# is tracked silently - the caller prints one summary line once the whole
+# batch (every bar/episode) is done, via get_batch_progress().
+_batch_lock = threading.Lock()
+_batch_total = 0
+_batch_done = 0
 
 
-class _TqdmPosition:
-    def __enter__(self):
-        with _position_lock:
-            pos = 0
-            while pos in _positions_in_use:
-                pos += 1
-            _positions_in_use.add(pos)
-            self.pos = pos
-        return self.pos
+def set_batch_size(total):
+    """Call once before starting a batch of parallel downloads."""
+    global _batch_total, _batch_done
+    with _batch_lock:
+        _batch_total = total
+        _batch_done = 0
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        with _position_lock:
-            _positions_in_use.discard(self.pos)
+
+def get_batch_progress():
+    with _batch_lock:
+        return _batch_done, _batch_total
+
+
+def _report_episode_done(label):
+    global _batch_done
+    with _batch_lock:
+        _batch_done += 1
+        total = _batch_total
+    if not total:
+        print_status(f"{label} assembled", "success")
 
 def download_video(video_url, save_path, use_ts_threading=False, url='',automatic_mp4=False, threaded_mp4=False, interactive=True):
-    print_status(f"Starting download: {os.path.basename(save_path)}", "loading")
+    # "Starting download" is printed by the caller (download_episode.py) as
+    # part of its single atomic per-episode header block, not here.
     ua = DEFAULT_USER_AGENT
 
     target = url if url else video_url
@@ -139,7 +153,7 @@ def download_video(video_url, save_path, use_ts_threading=False, url='',automati
 
             if automatic_mp4 is False and use_ts_threading is False:
                 if interactive:
-                    print(f"\n{Colors.BOLD}{Colors.OKCYAN}Threaded Download Option{Colors.ENDC}")
+                    tqdm.write(f"\n{Colors.BOLD}{Colors.OKCYAN}Threaded Download Option{Colors.ENDC}")
                     print_status("Threaded downloading is faster but should not be used on weak Wi-Fi.", "info")
                     use_threads = input(f"{Colors.BOLD}Use threaded download for faster performance? (y/n, default: n): {Colors.ENDC}").strip().lower()
                     use_threads = use_threads in ['y', 'yes', '1']
@@ -196,8 +210,10 @@ def download_video(video_url, save_path, use_ts_threading=False, url='',automati
                                 else:
                                     print_status(f"Failed to download segment {i+1}: {str(e)}", "error")
                                     return False, None
-            
-            print_status(f"Combined {len(segments)} segments into {temp_ts_path}", "success")
+
+            if _batch_total == 0:
+                print_status(f"Combined {len(segments)} segments into {temp_ts_path}", "success")
+            _report_episode_done(random_string)
             return True, temp_ts_path
         else:
             response = requests.get(video_url, stream=True, headers=headers, timeout=30)
@@ -208,7 +224,7 @@ def download_video(video_url, save_path, use_ts_threading=False, url='',automati
                 return False, None
             
             os.makedirs(os.path.dirname(save_path), exist_ok=True)
-            
+
             with open(save_path, 'wb') as f:
                 with tqdm(
                     total=total_size,
@@ -223,8 +239,10 @@ def download_video(video_url, save_path, use_ts_threading=False, url='',automati
                         if chunk:
                             f.write(chunk)
                             pbar.update(len(chunk))
-            
-            print_status(f"Download completed successfully!", "success")
+
+            if _batch_total == 0:
+                print_status(f"Download completed successfully!", "success")
+            _report_episode_done(os.path.basename(save_path))
             return True, save_path
     except Exception as e:
         print_status(f"Download failed: {str(e)}", "error")

--- a/src/utils/download/verify_video_file.py
+++ b/src/utils/download/verify_video_file.py
@@ -1,0 +1,63 @@
+import subprocess
+
+from src.var import print_status
+
+
+def verify_video_file(path, timeout=30):
+    """Sanity-check a downloaded/converted video file with ffprobe.
+
+    Threaded batch downloads have been seen to silently produce corrupted
+    output (e.g. "moov atom not found" on the .mp4, or a genuinely damaged
+    source stream) while the tool still reported success - this catches
+    that instead of leaving a broken file mistaken for a good download.
+
+    Returns (True, None) if the file has a readable, non-zero duration,
+    otherwise (False, reason).
+    """
+    try:
+        result = subprocess.run(
+            [
+                "ffprobe", "-v", "error",
+                "-show_entries", "format=duration",
+                "-of", "default=noprint_wrappers=1:nokey=1",
+                path,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except FileNotFoundError:
+        # ffprobe not installed - can't verify, don't block on it
+        return True, None
+    except subprocess.TimeoutExpired:
+        return False, "ffprobe timed out while reading the file"
+
+    if result.returncode != 0:
+        reason = result.stderr.strip().splitlines()[-1] if result.stderr.strip() else "ffprobe failed"
+        return False, reason
+
+    try:
+        duration = float(result.stdout.strip())
+    except (ValueError, TypeError):
+        return False, "no duration reported (empty/corrupted file)"
+
+    if duration <= 0:
+        return False, f"invalid duration ({duration}s)"
+
+    return True, None
+
+
+def verify_or_warn(path, episode_num):
+    """Verify a file and print a clear warning (but don't raise) on failure.
+
+    Returns True/False so callers can decide whether to treat the episode
+    as failed (e.g. to trigger a fallback-player retry) or just warn.
+    """
+    ok, reason = verify_video_file(path)
+    if not ok:
+        print_status(
+            f"⚠️ Episode {episode_num} file failed verification ({reason}) - "
+            f"the download likely got corrupted: {path}",
+            "error",
+        )
+    return ok

--- a/src/utils/get/get_player_choice.py
+++ b/src/utils/get/get_player_choice.py
@@ -78,14 +78,18 @@ def get_player_choice(episodes, wanted_episodes=None):
     
     while True:
         try:
-            choice = input(f"\n{Colors.BOLD}Enter player number (1-{len(available_players)}) or type player name: {Colors.ENDC}").strip()
-            
+            choice = input(f"\n{Colors.BOLD}Enter player number (1-{len(available_players)}, 0 to cancel) or type player name: {Colors.ENDC}").strip()
+
+            if choice == "0":
+                print_status("Cancelled by user", "warning")
+                return None
+
             if choice.isdigit():
                 choice_idx = int(choice) - 1
                 if 0 <= choice_idx < len(available_players):
                     return available_players[choice_idx]
                 else:
-                    print_status(f"Please enter a number between 1 and {len(available_players)}", "error")
+                    print_status(f"Please enter a number between 0 and {len(available_players)}", "error")
             else:
                 player_input = choice.lower()
                 if player_input.isdigit():

--- a/src/utils/get/get_player_choice.py
+++ b/src/utils/get/get_player_choice.py
@@ -6,25 +6,48 @@ from src.var import Colors, print_status, print_separator, SourceDomains
 # Verifie dans le code d'extraction de chaque hebergeur, pas devine.
 SEGMENTED_HOSTS = {
     "vidmoly", "voe", "vidzy", "filemoon", "uqload", "ansembed",
-    "movearnpre", "embed4me", "lulustream", "luluvdo",
+    "movearnpre", "embed4me", "lulustream", "luluvdo", "vidhide",
 }
 # Sibnet et Sendvid renvoient un lien fichier unique (pas de decoupage
 # possible) - un seul flux, donc potentiellement plus lent sur un gros fichier.
 DIRECT_FILE_HOSTS = {"sibnet", "sendvid"}
 
 
-def is_fast_player(player_key):
+def _detect_host(player_key, urls=None):
+    """Resolve the real hoster key (vidmoly, sibnet, ...) for this player.
+
+    anime-sama names players generically ("Player 1", "Player 2" - the real
+    host is never in the JS variable name, only in the URLs themselves),
+    while Nakanime already gives us the real host name directly in
+    player_key. Try the key first, fall back to sniffing the URLs.
+    """
+    base = player_key.split(" ")[0].lower()
+    if base in SEGMENTED_HOSTS or base in DIRECT_FILE_HOSTS:
+        return base
+
+    for url in (urls or []):
+        if not url:
+            continue
+        url_lower = url.lower()
+        for host_key, domains in SourceDomains.DOMAIN_MAP.items():
+            domain_list = domains if isinstance(domains, list) else [domains]
+            if any(d in url_lower for d in domain_list):
+                return host_key
+    return base
+
+
+def is_fast_player(player_key, urls=None):
     """True if this player serves HLS/m3u8 (segmented, multi-thread capable)
     rather than a single direct file - used to prefer fast alternatives when
     a player fails and the downloader falls back to another one."""
-    return player_key.split(" ")[0].lower() in SEGMENTED_HOSTS
+    return _detect_host(player_key, urls) in SEGMENTED_HOSTS
 
 
-def _speed_hint(player_key):
-    base = player_key.split(" ")[0].lower()
-    if base in SEGMENTED_HOSTS:
+def _speed_hint(player_key, urls=None):
+    host = _detect_host(player_key, urls)
+    if host in SEGMENTED_HOSTS:
         return f"{Colors.OKGREEN}⚡ Fast{Colors.ENDC}"
-    if base in DIRECT_FILE_HOSTS:
+    if host in DIRECT_FILE_HOSTS:
         return f"{Colors.WARNING}Single file{Colors.ENDC}"
     return None
 
@@ -49,7 +72,7 @@ def get_player_choice(episodes, wanted_episodes=None):
             if SourceDomains.is_valid_url(url, category=player)
         )
         total_episodes = len(urls_to_check)
-        speed_hint = _speed_hint(player)
+        speed_hint = _speed_hint(player, urls_to_check)
         speed_suffix = f" [{speed_hint}{Colors.OKCYAN}]" if speed_hint else ""
         print(f"{Colors.OKCYAN}  {i}. {player} ({working_episodes}/{total_episodes} working episodes){speed_suffix}{Colors.ENDC}")
     

--- a/src/utils/print/print_episodes.py
+++ b/src/utils/print/print_episodes.py
@@ -1,4 +1,5 @@
 from src.var import Colors, print_separator, SourceDomains
+from src.utils.get.get_player_choice import _speed_hint
 
 def print_episodes(episodes, wanted_episodes=None):
     SOURCE_CONFIG = {
@@ -40,7 +41,9 @@ def print_episodes(episodes, wanted_episodes=None):
     print_separator("=")
     
     for category, urls in episodes.items():
-        print(f"\n{Colors.BOLD}{Colors.OKCYAN}🎮 {category}:{Colors.ENDC} ({len(urls)} episodes)")
+        speed_hint = _speed_hint(category, urls)
+        speed_suffix = f" [{speed_hint}{Colors.OKCYAN}]" if speed_hint else ""
+        print(f"\n{Colors.BOLD}{Colors.OKCYAN}🎮 {category}:{Colors.ENDC} ({len(urls)} episodes){speed_suffix}")
         print_separator("─", 40)
 
         for i, url in enumerate(urls, start=1):

--- a/src/utils/settings/settings_menu.py
+++ b/src/utils/settings/settings_menu.py
@@ -50,12 +50,14 @@ def settings_menu():
             print(f" - {Colors.OKCYAN}external{Colors.ENDC} : tag the folder name instead - "
                   f"[tvdb-XXXX] or [imdbid-ttXXXXXXX] (for {Colors.OKCYAN}TheTVDB{Colors.ENDC}/IMDb-based Plex agents; "
                   f"you type the exact tag once per anime when prompted)")
-            new_mode = input(f"{Colors.BOLD}Mode (mal/external): {Colors.ENDC}").strip().lower()
-            if new_mode in ("mal", "external"):
+            print(f" - {Colors.OKCYAN}none{Colors.ENDC}     : do nothing - no .match file, no folder tag, "
+                  f"no prompts at all (same as always passing {Colors.OKCYAN}--no-mal{Colors.ENDC})")
+            new_mode = input(f"{Colors.BOLD}Mode (mal/external/none): {Colors.ENDC}").strip().lower()
+            if new_mode in ("mal", "external", "none"):
                 set_setting("identification_mode", new_mode)
                 print_status(f"Identification method set to '{new_mode}'.", "success")
             else:
-                print_status("Cancelled (must be mal or external).", "warning")
+                print_status("Cancelled (must be mal, external or none).", "warning")
             input("Press Enter to continue...")
 
         elif choice == '3':

--- a/src/utils/settings/settings_menu.py
+++ b/src/utils/settings/settings_menu.py
@@ -9,15 +9,22 @@ def settings_menu():
         print_separator()
         
         current_template = get_setting("save_template", "./videos/{anime}/{season}")
-        
+        current_id_mode = get_setting("identification_mode", "mal")
+        current_tvdb_key = get_setting("tvdb_api_key", "")
+        tvdb_key_display = (current_tvdb_key[:4] + "…") if current_tvdb_key else f"{Colors.FAIL}not set{Colors.ENDC}"
+
         print(f"{Colors.OKCYAN}1. Change Save Path Template{Colors.ENDC}")
         print(f"   {Colors.WARNING}Current: {current_template}{Colors.ENDC}")
         print(f"   {Colors.FAIL}Keywords: {{anime}}, {{season}}{Colors.ENDC}")
+        print(f"\n{Colors.OKCYAN}2. Change Plex Identification Method{Colors.ENDC}")
+        print(f"   {Colors.WARNING}Current: {current_id_mode}{Colors.ENDC}")
+        print(f"\n{Colors.OKCYAN}3. Set TVDB API Key{Colors.ENDC} {Colors.FAIL}(requires a free account, see below){Colors.ENDC}")
+        print(f"   {Colors.WARNING}Current: {tvdb_key_display}{Colors.ENDC}")
         print(f"\n{Colors.OKCYAN}0. Back to Main Menu{Colors.ENDC}")
         print_separator()
-        
+
         choice = input(f"{Colors.BOLD}Select option: {Colors.ENDC}").strip()
-        
+
         if choice == '1':
             print(f"\n{Colors.BOLD}Enter new save path template:{Colors.ENDC}")
             print(f"You can use keywords {Colors.WARNING}{{anime}}{Colors.ENDC} and {Colors.WARNING}{{season}}{Colors.ENDC} which will be automatically replaced.")
@@ -35,7 +42,39 @@ def settings_menu():
             else:
                 print_status("Cancelled.", "warning")
             input("Press Enter to continue...")
-            
+
+        elif choice == '2':
+            print(f"\n{Colors.BOLD}How should downloaded seasons be identified to Plex?{Colors.ENDC}")
+            print(f" - {Colors.OKCYAN}mal{Colors.ENDC}      : write a .match file with the MyAnimeList id "
+                  f"(for the {Colors.OKCYAN}MyAnimeList.bundle{Colors.ENDC} Plex agent - default)")
+            print(f" - {Colors.OKCYAN}external{Colors.ENDC} : tag the folder name instead - "
+                  f"[tvdb-XXXX] or [imdbid-ttXXXXXXX] (for {Colors.OKCYAN}TheTVDB{Colors.ENDC}/IMDb-based Plex agents; "
+                  f"you type the exact tag once per anime when prompted)")
+            new_mode = input(f"{Colors.BOLD}Mode (mal/external): {Colors.ENDC}").strip().lower()
+            if new_mode in ("mal", "external"):
+                set_setting("identification_mode", new_mode)
+                print_status(f"Identification method set to '{new_mode}'.", "success")
+            else:
+                print_status("Cancelled (must be mal or external).", "warning")
+            input("Press Enter to continue...")
+
+        elif choice == '3':
+            print(f"\n{Colors.BOLD}TVDB API Key{Colors.ENDC}")
+            print(f"Only needed for the 'external' identification mode's TVDB search results")
+            print(f"(without a key, only IMDb search results are shown - IMDb needs no key).")
+            print(f"{Colors.BOLD}This REQUIRES a free TheTVDB account:{Colors.ENDC}")
+            print(f"  1. Create a free account at {Colors.OKCYAN}https://thetvdb.com/auth/register{Colors.ENDC}")
+            print(f"  2. Go to {Colors.OKCYAN}https://thetvdb.com/api-information{Colors.ENDC} and generate a")
+            print(f"     'User Supported' API key (no cost, personal use)")
+            print(f"  3. Paste that key below")
+            new_key = input(f"{Colors.BOLD}TVDB API key (blank to clear): {Colors.ENDC}").strip()
+            set_setting("tvdb_api_key", new_key)
+            if new_key:
+                print_status("TVDB API key saved.", "success")
+            else:
+                print_status("TVDB API key cleared - TVDB search results disabled.", "warning")
+            input("Press Enter to continue...")
+
         elif choice == '0':
             break
         else:

--- a/src/utils/tqdm_position.py
+++ b/src/utils/tqdm_position.py
@@ -1,0 +1,24 @@
+import threading
+
+# Assigns each concurrent tqdm bar (downloads, conversions, ...) its own
+# terminal line instead of letting them all draw over line 0 - without this,
+# several bars running in parallel (batch threaded mode) produce a garbled,
+# overlapping display. Shared across download and conversion so the two
+# phases don't fight over the same rows.
+_lock = threading.Lock()
+_in_use = set()
+
+
+class TqdmPosition:
+    def __enter__(self):
+        with _lock:
+            pos = 0
+            while pos in _in_use:
+                pos += 1
+            _in_use.add(pos)
+            self.pos = pos
+        return self.pos
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        with _lock:
+            _in_use.discard(self.pos)

--- a/src/utils/ts/_fix_ts_worker.py
+++ b/src/utils/ts/_fix_ts_worker.py
@@ -1,0 +1,25 @@
+"""Standalone entry point for running fix_ts() in its own process.
+
+Run as: python _fix_ts_worker.py <infile> <outfile>
+
+fix_ts() (PyAV-based remux/encode) has been observed to hang indefinitely
+on certain input files with no CPU usage - a genuine block inside the
+native av library, not something Python-level code can interrupt (a
+blocked thread can't be killed). Running it in a separate OS process
+instead lets the caller enforce a hard timeout and kill it if needed.
+"""
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))))
+
+from src.utils.ts.fix_ts import fix_ts
+
+if __name__ == "__main__":
+    infile, outfile = sys.argv[1], sys.argv[2]
+    try:
+        fix_ts(infile, outfile)
+        sys.exit(0)
+    except Exception as e:
+        print(f"fix_ts failed: {e}", file=sys.stderr)
+        sys.exit(1)

--- a/src/utils/ts/_fix_ts_worker.py
+++ b/src/utils/ts/_fix_ts_worker.py
@@ -11,6 +11,16 @@ instead lets the caller enforce a hard timeout and kill it if needed.
 import sys
 import os
 
+# This subprocess's stdout/stderr default to the Windows console codepage
+# (cp1252) rather than UTF-8 when captured by the parent via subprocess.run,
+# which crashes on the emoji used in print_status() (e.g. "⏳"). Force UTF-8
+# before anything else prints.
+try:
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+except AttributeError:
+    pass  # Python <3.7 fallback: not expected here, but don't crash on it.
+
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))))
 
 from src.utils.ts.fix_ts import fix_ts

--- a/src/utils/ts/convert_ts_to_mp4.py
+++ b/src/utils/ts/convert_ts_to_mp4.py
@@ -21,6 +21,8 @@ def _run_fix_ts_with_timeout(input_path, output_path, timeout=_FIX_TS_TIMEOUT):
             timeout=timeout,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
         )
     except subprocess.TimeoutExpired:
         raise TimeoutError(f"fix_ts timed out after {timeout}s (likely stuck in PyAV) - {input_path}")
@@ -43,24 +45,16 @@ def convert_ts_to_mp4(input_path, output_path, pre_selected_tool=None):
 
             output_path = os.path.splitext(input_path)[0] + '.mp4'
             ffmpeg_cmd = [
-            "ffmpeg", "-y",
+            "ffmpeg", "-y", "-hide_banner", "-loglevel", "error", "-nostats",
             "-i", input_path,
             "-c:v", "copy",
             "-c:a", "copy",
             output_path
         ]
-            print_status(f"Running FFmpeg command: {' '.join(ffmpeg_cmd)}", "info")
-            process = subprocess.Popen(
-                ffmpeg_cmd,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                text=True,
-                bufsize=1,
-                universal_newlines=True
-            )
-            for line in process.stdout:
-                print(line, end='')
-            process.wait()
+            print_status(f"Converting with FFmpeg: {os.path.basename(input_path)}", "loading")
+            process = subprocess.run(ffmpeg_cmd, capture_output=True, text=True, encoding="utf-8", errors="replace")
+            if process.stderr.strip():
+                print_status(process.stderr.strip(), "warning")
             if process.returncode == 0:
                 print_status(f"Video converted successfully to {output_path}", "success")
                 return True, output_path
@@ -84,17 +78,16 @@ def convert_ts_to_mp4(input_path, output_path, pre_selected_tool=None):
                     try:
                         ff_output = os.path.splitext(input_path)[0] + '.mp4'
                         ffmpeg_cmd = [
-                            "ffmpeg", "-y",
+                            "ffmpeg", "-y", "-hide_banner", "-loglevel", "error", "-nostats",
                             "-i", input_path,
                             "-c:v", "copy",
                             "-c:a", "copy",
                             ff_output
                         ]
-                        print_status("AV failed — falling back to FFmpeg", "info")
-                        process = subprocess.Popen(ffmpeg_cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
-                        for line in process.stdout:
-                            print(line, end='')
-                        process.wait()
+                        print_status(f"AV failed - falling back to FFmpeg: {os.path.basename(input_path)}", "loading")
+                        process = subprocess.run(ffmpeg_cmd, capture_output=True, text=True, encoding="utf-8", errors="replace")
+                        if process.stderr.strip():
+                            print_status(process.stderr.strip(), "warning")
                         if process.returncode == 0:
                             print_status(f"Video converted successfully to {ff_output}", "success")
                             return True, ff_output

--- a/src/utils/ts/convert_ts_to_mp4.py
+++ b/src/utils/ts/convert_ts_to_mp4.py
@@ -1,7 +1,31 @@
 import subprocess
 import os
+import sys
 from src.var        import print_status
-from src.utils.ts.fix_ts import fix_ts
+
+_FIX_TS_WORKER = os.path.join(os.path.dirname(os.path.abspath(__file__)), "_fix_ts_worker.py")
+_FIX_TS_TIMEOUT = 180
+
+
+def _run_fix_ts_with_timeout(input_path, output_path, timeout=_FIX_TS_TIMEOUT):
+    """Run fix_ts() in a separate process with a hard timeout.
+
+    fix_ts() (PyAV) has been observed to hang indefinitely on certain input
+    files with the CPU sitting at 0% - a block inside the native av library
+    itself, which a Python thread cannot be interrupted out of. A
+    subprocess CAN be killed outright, so that's what enforces the limit.
+    """
+    try:
+        result = subprocess.run(
+            [sys.executable, _FIX_TS_WORKER, input_path, output_path],
+            timeout=timeout,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.TimeoutExpired:
+        raise TimeoutError(f"fix_ts timed out after {timeout}s (likely stuck in PyAV) - {input_path}")
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or "fix_ts subprocess failed")
 
 def convert_ts_to_mp4(input_path, output_path, pre_selected_tool=None):
     if not os.path.exists(input_path):
@@ -49,7 +73,7 @@ def convert_ts_to_mp4(input_path, output_path, pre_selected_tool=None):
     
     elif pre_selected_tool == 'av':
         try:
-            fix_ts(input_path, output_path)
+            _run_fix_ts_with_timeout(input_path, output_path)
             print_status(f"Video converted successfully to {output_path}", "success")
             return True, output_path
         except Exception as e:

--- a/src/utils/ts/fix_ts.py
+++ b/src/utils/ts/fix_ts.py
@@ -1,6 +1,18 @@
 import os
 import av
 
+from src.var import print_status
+
+# fix_ts() used to print nothing at all while remuxing/encoding - which
+# left a long silent stretch after all .ts downloads finished. A live tqdm
+# bar was tried here too, but mixing bars created at different times across
+# threads (download bars finishing/freeing their position while a
+# conversion bar claims it mid-batch, with plain print_status lines
+# interleaved in between) broke tqdm's row bookkeeping and produced
+# garbled, overlapping output. Kept simple instead: one line when a
+# conversion starts, one when it finishes - no live in-between updates.
+
+
 def sanitize_ts_file(filepath):
 
     if not os.path.exists(filepath):
@@ -40,7 +52,12 @@ def sanitize_ts_file(filepath):
 
 
 def fix_ts(infile, outfile):
+    label = os.path.basename(outfile)
+    print_status(f"Converting to mp4: {label}", "loading")
+    return _fix_ts_impl(infile, outfile)
 
+
+def _fix_ts_impl(infile, outfile):
     sanitize_ts_file(infile)
 
     open_options = {

--- a/src/var.py
+++ b/src/var.py
@@ -1,4 +1,5 @@
 import random
+from tqdm import tqdm
 
 DEFAULT_USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
 
@@ -20,6 +21,11 @@ class SourceDomains:
         "luluvdo": ("LuluStream", ["luluvdo.com", "lulustream.com", "lulu"]),
         "vidzy": ("Vidzy", ["vidzy.live", "vidzy.org", "vidzy"]),
         "nakanime": ("Nakanime", ["nakanime.tv", "nakanime.fr", "nakanime"]),
+        # VidHide player software (jwplayer + HLS/m3u8) - seen mirrored under
+        # rotating domain names that don't contain "vidhide" at all (e.g.
+        # minochinos.com); identified by the "/vidhide/..." asset paths in
+        # the embed page itself rather than the domain.
+        "vidhide": ("VidHide", ["minochinos.com", "vidhide"]),
     }
 
     ONEUPLOAD = _SOURCES["oneupload"][1]
@@ -154,20 +160,27 @@ def print_tutorial():
     print(tutorial)
 
 def print_separator(char="─", length=65, title=""):
+    # tqdm.write() (not print()) so this coordinates with any active tqdm
+    # progress bars - it clears them, writes the line, then redraws them,
+    # instead of writing straight to the terminal and visually colliding
+    # with a bar mid-redraw (which plain print() does, even though the
+    # underlying write itself is atomic).
     if title:
         title_str = f"  {title}  "
         side = max(0, (length - len(title_str)) // 2)
         line = char * side + title_str + char * (length - side - len(title_str))
-        print(f"{Colors.OKBLUE}{Colors.BOLD}{line}{Colors.ENDC}")
+        tqdm.write(f"{Colors.OKBLUE}{Colors.BOLD}{line}{Colors.ENDC}")
     else:
-        print(f"{Colors.OKBLUE}{char * length}{Colors.ENDC}")
+        tqdm.write(f"{Colors.OKBLUE}{char * length}{Colors.ENDC}")
 
 def print_section(title, emoji=""):
     label = f" {emoji}  {title} " if emoji else f" {title} "
     border = "─" * (len(label) + 2)
-    print(f"\n{Colors.BOLD}{Colors.HEADER}┌{border}┐")
-    print(f"│ {label} │")
-    print(f"└{border}┘{Colors.ENDC}")
+    tqdm.write(
+        f"\n{Colors.BOLD}{Colors.HEADER}┌{border}┐\n"
+        f"│ {label} │\n"
+        f"└{border}┘{Colors.ENDC}"
+    )
 
 def print_status(message, status_type="info"):
     icons = {
@@ -186,4 +199,4 @@ def print_status(message, status_type="info"):
     }
     icon  = icons.get(status_type, "ℹ️ ")
     color = colors.get(status_type, Colors.OKBLUE)
-    print(f"{color}{icon}{message}{Colors.ENDC}")
+    tqdm.write(f"{color}{icon}{message}{Colors.ENDC}")


### PR DESCRIPTION
## Summary
- Season-aware MAL search (per-season query variants, multi-MAL-entry Part 1/2 support with chronological ordering, English titles shown, candidate picker always shown on ambiguity)
- Real host detection from episode URLs for accurate fast/slow player speed hints on anime-sama sourced content; VidHide added as a known host
- Post-download/conversion file verification via ffprobe instead of trusting a silent success
- Batch threaded downloads: live per-episode progress bars kept during download (no text interleaved - that was corrupting tqdm's row positioning), one summary line once the whole download phase is done, conversion run as its own clearly-separated phase afterward
- .ts -> .mp4 conversion done sequentially instead of in parallel: PyAV's per-packet loop is GIL-bound and concurrent large-file reads thrash disk I/O - live-tested to make a 14-episode batch take 10+ minutes with almost no progress instead of a few minutes sequential
- PyAV conversion now runs in an isolated subprocess with a hard timeout, falling back to FFmpeg automatically - a thread stuck in native PyAV code can't be killed, a subprocess can (this was live-observed to hang indefinitely on at least one real file)

## Test plan
- [x] Live-tested a 14-episode Fire Force S3 batch download (Vidmoly VF) end to end
- [x] Verified all 14 converted .mp4 files have valid, correct durations via ffprobe
- [x] Verified the multi-MAL-entry (Part 1/Part 2) folder creation and chronological ordering
- [x] Verified the PyAV timeout+FFmpeg fallback path completes instead of hanging